### PR TITLE
feat/mobile goal images profile links

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,9 @@
       "name": "cherry-chores-api",
       "version": "0.1.0",
       "dependencies": {
+        "@aws-sdk/client-s3": "^3.645.0",
+        "@aws-sdk/s3-presigned-post": "^3.645.0",
+        "@aws-sdk/s3-request-presigner": "^3.645.0",
         "cors": "^2.8.5",
         "express": "^4.19.2",
         "express-session": "^1.17.3",
@@ -84,6 +87,928 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/@aws-crypto/crc32": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
+      "integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/crc32c": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32c/-/crc32c-5.2.0.tgz",
+      "integrity": "sha512-+iWb8qaHLYKrNvGRbiYRHSdKRWhto5XlZUEBwDjYNf+ly5SVYG6zEoYIdxvf5R3zyeP16w4PLBn3rH1xc74Rag==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha1-browser/-/sha1-browser-5.2.0.tgz",
+      "integrity": "sha512-OH6lveCFfcDjX4dbAvCFSYUjJZjDr/3XJ3xHtjn3Oj5b9RjojQo8npoLeA/bNwkOkrSQ0wgrHzXk4tDRxGKJeg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3": {
+      "version": "3.888.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.888.0.tgz",
+      "integrity": "sha512-MgYyF/qpvCMYVSiOpRJ5C/EtdFxuYAeF5SprtMsbf71xBiiCH5GurB616i+ZxJqHlfhBQTTvR0qugnWvk1Wqvw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha1-browser": "5.2.0",
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.888.0",
+        "@aws-sdk/credential-provider-node": "3.888.0",
+        "@aws-sdk/middleware-bucket-endpoint": "3.887.0",
+        "@aws-sdk/middleware-expect-continue": "3.887.0",
+        "@aws-sdk/middleware-flexible-checksums": "3.888.0",
+        "@aws-sdk/middleware-host-header": "3.887.0",
+        "@aws-sdk/middleware-location-constraint": "3.887.0",
+        "@aws-sdk/middleware-logger": "3.887.0",
+        "@aws-sdk/middleware-recursion-detection": "3.887.0",
+        "@aws-sdk/middleware-sdk-s3": "3.888.0",
+        "@aws-sdk/middleware-ssec": "3.887.0",
+        "@aws-sdk/middleware-user-agent": "3.888.0",
+        "@aws-sdk/region-config-resolver": "3.887.0",
+        "@aws-sdk/signature-v4-multi-region": "3.888.0",
+        "@aws-sdk/types": "3.887.0",
+        "@aws-sdk/util-endpoints": "3.887.0",
+        "@aws-sdk/util-user-agent-browser": "3.887.0",
+        "@aws-sdk/util-user-agent-node": "3.888.0",
+        "@aws-sdk/xml-builder": "3.887.0",
+        "@smithy/config-resolver": "^4.2.1",
+        "@smithy/core": "^3.11.0",
+        "@smithy/eventstream-serde-browser": "^4.1.1",
+        "@smithy/eventstream-serde-config-resolver": "^4.2.1",
+        "@smithy/eventstream-serde-node": "^4.1.1",
+        "@smithy/fetch-http-handler": "^5.2.1",
+        "@smithy/hash-blob-browser": "^4.1.1",
+        "@smithy/hash-node": "^4.1.1",
+        "@smithy/hash-stream-node": "^4.1.1",
+        "@smithy/invalid-dependency": "^4.1.1",
+        "@smithy/md5-js": "^4.1.1",
+        "@smithy/middleware-content-length": "^4.1.1",
+        "@smithy/middleware-endpoint": "^4.2.1",
+        "@smithy/middleware-retry": "^4.2.1",
+        "@smithy/middleware-serde": "^4.1.1",
+        "@smithy/middleware-stack": "^4.1.1",
+        "@smithy/node-config-provider": "^4.2.1",
+        "@smithy/node-http-handler": "^4.2.1",
+        "@smithy/protocol-http": "^5.2.1",
+        "@smithy/smithy-client": "^4.6.1",
+        "@smithy/types": "^4.5.0",
+        "@smithy/url-parser": "^4.1.1",
+        "@smithy/util-base64": "^4.1.0",
+        "@smithy/util-body-length-browser": "^4.1.0",
+        "@smithy/util-body-length-node": "^4.1.0",
+        "@smithy/util-defaults-mode-browser": "^4.1.1",
+        "@smithy/util-defaults-mode-node": "^4.1.1",
+        "@smithy/util-endpoints": "^3.1.1",
+        "@smithy/util-middleware": "^4.1.1",
+        "@smithy/util-retry": "^4.1.1",
+        "@smithy/util-stream": "^4.3.1",
+        "@smithy/util-utf8": "^4.1.0",
+        "@smithy/util-waiter": "^4.1.1",
+        "@types/uuid": "^9.0.1",
+        "tslib": "^2.6.2",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso": {
+      "version": "3.888.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.888.0.tgz",
+      "integrity": "sha512-8CLy/ehGKUmekjH+VtZJ4w40PqDg3u0K7uPziq/4P8Q7LLgsy8YQoHNbuY4am7JU3HWrqLXJI9aaz1+vPGPoWA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.888.0",
+        "@aws-sdk/middleware-host-header": "3.887.0",
+        "@aws-sdk/middleware-logger": "3.887.0",
+        "@aws-sdk/middleware-recursion-detection": "3.887.0",
+        "@aws-sdk/middleware-user-agent": "3.888.0",
+        "@aws-sdk/region-config-resolver": "3.887.0",
+        "@aws-sdk/types": "3.887.0",
+        "@aws-sdk/util-endpoints": "3.887.0",
+        "@aws-sdk/util-user-agent-browser": "3.887.0",
+        "@aws-sdk/util-user-agent-node": "3.888.0",
+        "@smithy/config-resolver": "^4.2.1",
+        "@smithy/core": "^3.11.0",
+        "@smithy/fetch-http-handler": "^5.2.1",
+        "@smithy/hash-node": "^4.1.1",
+        "@smithy/invalid-dependency": "^4.1.1",
+        "@smithy/middleware-content-length": "^4.1.1",
+        "@smithy/middleware-endpoint": "^4.2.1",
+        "@smithy/middleware-retry": "^4.2.1",
+        "@smithy/middleware-serde": "^4.1.1",
+        "@smithy/middleware-stack": "^4.1.1",
+        "@smithy/node-config-provider": "^4.2.1",
+        "@smithy/node-http-handler": "^4.2.1",
+        "@smithy/protocol-http": "^5.2.1",
+        "@smithy/smithy-client": "^4.6.1",
+        "@smithy/types": "^4.5.0",
+        "@smithy/url-parser": "^4.1.1",
+        "@smithy/util-base64": "^4.1.0",
+        "@smithy/util-body-length-browser": "^4.1.0",
+        "@smithy/util-body-length-node": "^4.1.0",
+        "@smithy/util-defaults-mode-browser": "^4.1.1",
+        "@smithy/util-defaults-mode-node": "^4.1.1",
+        "@smithy/util-endpoints": "^3.1.1",
+        "@smithy/util-middleware": "^4.1.1",
+        "@smithy/util-retry": "^4.1.1",
+        "@smithy/util-utf8": "^4.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.888.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.888.0.tgz",
+      "integrity": "sha512-L3S2FZywACo4lmWv37Y4TbefuPJ1fXWyWwIJ3J4wkPYFJ47mmtUPqThlVrSbdTHkEjnZgJe5cRfxk0qCLsFh1w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.887.0",
+        "@aws-sdk/xml-builder": "3.887.0",
+        "@smithy/core": "^3.11.0",
+        "@smithy/node-config-provider": "^4.2.1",
+        "@smithy/property-provider": "^4.0.5",
+        "@smithy/protocol-http": "^5.2.1",
+        "@smithy/signature-v4": "^5.1.3",
+        "@smithy/smithy-client": "^4.6.1",
+        "@smithy/types": "^4.5.0",
+        "@smithy/util-base64": "^4.1.0",
+        "@smithy/util-body-length-browser": "^4.1.0",
+        "@smithy/util-middleware": "^4.1.1",
+        "@smithy/util-utf8": "^4.1.0",
+        "fast-xml-parser": "5.2.5",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.888.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.888.0.tgz",
+      "integrity": "sha512-shPi4AhUKbIk7LugJWvNpeZA8va7e5bOHAEKo89S0Ac8WDZt2OaNzbh/b9l0iSL2eEyte8UgIsYGcFxOwIF1VA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.888.0",
+        "@aws-sdk/types": "3.887.0",
+        "@smithy/property-provider": "^4.0.5",
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.888.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.888.0.tgz",
+      "integrity": "sha512-Jvuk6nul0lE7o5qlQutcqlySBHLXOyoPtiwE6zyKbGc7RVl0//h39Lab7zMeY2drMn8xAnIopL4606Fd8JI/Hw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.888.0",
+        "@aws-sdk/types": "3.887.0",
+        "@smithy/fetch-http-handler": "^5.2.1",
+        "@smithy/node-http-handler": "^4.2.1",
+        "@smithy/property-provider": "^4.0.5",
+        "@smithy/protocol-http": "^5.2.1",
+        "@smithy/smithy-client": "^4.6.1",
+        "@smithy/types": "^4.5.0",
+        "@smithy/util-stream": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.888.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.888.0.tgz",
+      "integrity": "sha512-M82ItvS5yq+tO6ZOV1ruaVs2xOne+v8HW85GFCXnz8pecrzYdgxh6IsVqEbbWruryG/mUGkWMbkBZoEsy4MgyA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.888.0",
+        "@aws-sdk/credential-provider-env": "3.888.0",
+        "@aws-sdk/credential-provider-http": "3.888.0",
+        "@aws-sdk/credential-provider-process": "3.888.0",
+        "@aws-sdk/credential-provider-sso": "3.888.0",
+        "@aws-sdk/credential-provider-web-identity": "3.888.0",
+        "@aws-sdk/nested-clients": "3.888.0",
+        "@aws-sdk/types": "3.887.0",
+        "@smithy/credential-provider-imds": "^4.0.7",
+        "@smithy/property-provider": "^4.0.5",
+        "@smithy/shared-ini-file-loader": "^4.0.5",
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.888.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.888.0.tgz",
+      "integrity": "sha512-KCrQh1dCDC8Y+Ap3SZa6S81kHk+p+yAaOQ5jC3dak4zhHW3RCrsGR/jYdemTOgbEGcA6ye51UbhWfrrlMmeJSA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.888.0",
+        "@aws-sdk/credential-provider-http": "3.888.0",
+        "@aws-sdk/credential-provider-ini": "3.888.0",
+        "@aws-sdk/credential-provider-process": "3.888.0",
+        "@aws-sdk/credential-provider-sso": "3.888.0",
+        "@aws-sdk/credential-provider-web-identity": "3.888.0",
+        "@aws-sdk/types": "3.887.0",
+        "@smithy/credential-provider-imds": "^4.0.7",
+        "@smithy/property-provider": "^4.0.5",
+        "@smithy/shared-ini-file-loader": "^4.0.5",
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.888.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.888.0.tgz",
+      "integrity": "sha512-+aX6piSukPQ8DUS4JAH344GePg8/+Q1t0+kvSHAZHhYvtQ/1Zek3ySOJWH2TuzTPCafY4nmWLcQcqvU1w9+4Lw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.888.0",
+        "@aws-sdk/types": "3.887.0",
+        "@smithy/property-provider": "^4.0.5",
+        "@smithy/shared-ini-file-loader": "^4.0.5",
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.888.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.888.0.tgz",
+      "integrity": "sha512-b1ZJji7LJ6E/j1PhFTyvp51in2iCOQ3VP6mj5H6f5OUnqn7efm41iNMoinKr87n0IKZw7qput5ggXVxEdPhouA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.888.0",
+        "@aws-sdk/core": "3.888.0",
+        "@aws-sdk/token-providers": "3.888.0",
+        "@aws-sdk/types": "3.887.0",
+        "@smithy/property-provider": "^4.0.5",
+        "@smithy/shared-ini-file-loader": "^4.0.5",
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.888.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.888.0.tgz",
+      "integrity": "sha512-7P0QNtsDzMZdmBAaY/vY1BsZHwTGvEz3bsn2bm5VSKFAeMmZqsHK1QeYdNsFjLtegnVh+wodxMq50jqLv3LFlA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.888.0",
+        "@aws-sdk/nested-clients": "3.888.0",
+        "@aws-sdk/types": "3.887.0",
+        "@smithy/property-provider": "^4.0.5",
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-bucket-endpoint": {
+      "version": "3.887.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.887.0.tgz",
+      "integrity": "sha512-qRCte/3MtNiMhPh4ZEGk9cHfAXq6IDTflvi2t1tkOIVZFyshkSCvNQNJrrE2D/ljVbOK1f3XbBDaF43EoQzIRQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.887.0",
+        "@aws-sdk/util-arn-parser": "3.873.0",
+        "@smithy/node-config-provider": "^4.2.1",
+        "@smithy/protocol-http": "^5.2.1",
+        "@smithy/types": "^4.5.0",
+        "@smithy/util-config-provider": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-expect-continue": {
+      "version": "3.887.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.887.0.tgz",
+      "integrity": "sha512-AlrTZZScDTG9SYeT82BC5cK/6Q4N0miN5xqMW/pbBqP3fNXlsdJOWKB+EKD3V6DV41EV5GVKHKe/1065xKSQ4w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.887.0",
+        "@smithy/protocol-http": "^5.2.1",
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-flexible-checksums": {
+      "version": "3.888.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.888.0.tgz",
+      "integrity": "sha512-vdwd4wMAlXSg1bldhXyTsDSnyPP+bbEVihapejGKNd4gLfyyHwjTfbli+B/hEONGttQs5Dp54UMn8yW/UA189g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@aws-crypto/crc32c": "5.2.0",
+        "@aws-crypto/util": "5.2.0",
+        "@aws-sdk/core": "3.888.0",
+        "@aws-sdk/types": "3.887.0",
+        "@smithy/is-array-buffer": "^4.0.0",
+        "@smithy/node-config-provider": "^4.2.1",
+        "@smithy/protocol-http": "^5.2.1",
+        "@smithy/types": "^4.5.0",
+        "@smithy/util-middleware": "^4.1.1",
+        "@smithy/util-stream": "^4.3.1",
+        "@smithy/util-utf8": "^4.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.887.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.887.0.tgz",
+      "integrity": "sha512-ulzqXv6NNqdu/kr0sgBYupWmahISHY+azpJidtK6ZwQIC+vBUk9NdZeqQpy7KVhIk2xd4+5Oq9rxapPwPI21CA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.887.0",
+        "@smithy/protocol-http": "^5.2.1",
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-location-constraint": {
+      "version": "3.887.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.887.0.tgz",
+      "integrity": "sha512-eU/9Cq4gg2sS32bOomxdx2YF43kb+o70pMhnEBBnVVeqzE8co78SO5FQdWfRTfhNJgTyQ6Vgosx//CNMPIfZPg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.887.0",
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.887.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.887.0.tgz",
+      "integrity": "sha512-YbbgLI6jKp2qSoAcHnXrQ5jcuc5EYAmGLVFgMVdk8dfCfJLfGGSaOLxF4CXC7QYhO50s+mPPkhBYejCik02Kug==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.887.0",
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.887.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.887.0.tgz",
+      "integrity": "sha512-tjrUXFtQnFLo+qwMveq5faxP5MQakoLArXtqieHphSqZTXm21wDJM73hgT4/PQQGTwgYjDKqnqsE1hvk0hcfDw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.887.0",
+        "@aws/lambda-invoke-store": "^0.0.1",
+        "@smithy/protocol-http": "^5.2.1",
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-s3": {
+      "version": "3.888.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.888.0.tgz",
+      "integrity": "sha512-rKOFNfqgqOfrdcLGF8fcO75azWS2aq2ksRHFoIEFru5FJxzu/yDAhY4C2FKiP/X34xeIUS2SbE/gQgrgWHSN2g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.888.0",
+        "@aws-sdk/types": "3.887.0",
+        "@aws-sdk/util-arn-parser": "3.873.0",
+        "@smithy/core": "^3.11.0",
+        "@smithy/node-config-provider": "^4.2.1",
+        "@smithy/protocol-http": "^5.2.1",
+        "@smithy/signature-v4": "^5.1.3",
+        "@smithy/smithy-client": "^4.6.1",
+        "@smithy/types": "^4.5.0",
+        "@smithy/util-config-provider": "^4.0.0",
+        "@smithy/util-middleware": "^4.1.1",
+        "@smithy/util-stream": "^4.3.1",
+        "@smithy/util-utf8": "^4.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-ssec": {
+      "version": "3.887.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.887.0.tgz",
+      "integrity": "sha512-1ixZks0IDkdac1hjPe4vdLSuD9HznkhblCEb4T0wNyw3Ee1fdXg+MlcPWywzG5zkPXLcIrULUzJg/OSYfaDXcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.887.0",
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.888.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.888.0.tgz",
+      "integrity": "sha512-ZkcUkoys8AdrNNG7ATjqw2WiXqrhTvT+r4CIK3KhOqIGPHX0p0DQWzqjaIl7ZhSUToKoZ4Ud7MjF795yUr73oA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.888.0",
+        "@aws-sdk/types": "3.887.0",
+        "@aws-sdk/util-endpoints": "3.887.0",
+        "@smithy/core": "^3.11.0",
+        "@smithy/protocol-http": "^5.2.1",
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.888.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.888.0.tgz",
+      "integrity": "sha512-py4o4RPSGt+uwGvSBzR6S6cCBjS4oTX5F8hrHFHfPCdIOMVjyOBejn820jXkCrcdpSj3Qg1yUZXxsByvxc9Lyg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.888.0",
+        "@aws-sdk/middleware-host-header": "3.887.0",
+        "@aws-sdk/middleware-logger": "3.887.0",
+        "@aws-sdk/middleware-recursion-detection": "3.887.0",
+        "@aws-sdk/middleware-user-agent": "3.888.0",
+        "@aws-sdk/region-config-resolver": "3.887.0",
+        "@aws-sdk/types": "3.887.0",
+        "@aws-sdk/util-endpoints": "3.887.0",
+        "@aws-sdk/util-user-agent-browser": "3.887.0",
+        "@aws-sdk/util-user-agent-node": "3.888.0",
+        "@smithy/config-resolver": "^4.2.1",
+        "@smithy/core": "^3.11.0",
+        "@smithy/fetch-http-handler": "^5.2.1",
+        "@smithy/hash-node": "^4.1.1",
+        "@smithy/invalid-dependency": "^4.1.1",
+        "@smithy/middleware-content-length": "^4.1.1",
+        "@smithy/middleware-endpoint": "^4.2.1",
+        "@smithy/middleware-retry": "^4.2.1",
+        "@smithy/middleware-serde": "^4.1.1",
+        "@smithy/middleware-stack": "^4.1.1",
+        "@smithy/node-config-provider": "^4.2.1",
+        "@smithy/node-http-handler": "^4.2.1",
+        "@smithy/protocol-http": "^5.2.1",
+        "@smithy/smithy-client": "^4.6.1",
+        "@smithy/types": "^4.5.0",
+        "@smithy/url-parser": "^4.1.1",
+        "@smithy/util-base64": "^4.1.0",
+        "@smithy/util-body-length-browser": "^4.1.0",
+        "@smithy/util-body-length-node": "^4.1.0",
+        "@smithy/util-defaults-mode-browser": "^4.1.1",
+        "@smithy/util-defaults-mode-node": "^4.1.1",
+        "@smithy/util-endpoints": "^3.1.1",
+        "@smithy/util-middleware": "^4.1.1",
+        "@smithy/util-retry": "^4.1.1",
+        "@smithy/util-utf8": "^4.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.887.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.887.0.tgz",
+      "integrity": "sha512-VdSMrIqJ3yjJb/fY+YAxrH/lCVv0iL8uA+lbMNfQGtO5tB3Zx6SU9LEpUwBNX8fPK1tUpI65CNE4w42+MY/7Mg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.887.0",
+        "@smithy/node-config-provider": "^4.2.1",
+        "@smithy/types": "^4.5.0",
+        "@smithy/util-config-provider": "^4.0.0",
+        "@smithy/util-middleware": "^4.1.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/s3-presigned-post": {
+      "version": "3.888.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-presigned-post/-/s3-presigned-post-3.888.0.tgz",
+      "integrity": "sha512-gY8cmB2eR9o4a0Y3Eshfe9LTJLXH1PELH9Rdc7hr4UNubIu4QbBI6HIXOv39HwQpil1q9SXUTSpuKbZG4DhxGQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/client-s3": "3.888.0",
+        "@aws-sdk/types": "3.887.0",
+        "@aws-sdk/util-format-url": "3.887.0",
+        "@smithy/middleware-endpoint": "^4.2.1",
+        "@smithy/signature-v4": "^5.1.3",
+        "@smithy/types": "^4.5.0",
+        "@smithy/util-hex-encoding": "^4.0.0",
+        "@smithy/util-utf8": "^4.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/s3-request-presigner": {
+      "version": "3.888.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.888.0.tgz",
+      "integrity": "sha512-3VAF0tJxW0p/ttUzJEgrMe52zZVoEG9dcJGdp4N0RG+LD41lp7QuQEYAZ/LGn7mwJsT0q18+tEJ5XzKmJFrOiA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/signature-v4-multi-region": "3.888.0",
+        "@aws-sdk/types": "3.887.0",
+        "@aws-sdk/util-format-url": "3.887.0",
+        "@smithy/middleware-endpoint": "^4.2.1",
+        "@smithy/protocol-http": "^5.2.1",
+        "@smithy/smithy-client": "^4.6.1",
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.888.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.888.0.tgz",
+      "integrity": "sha512-FmOHUaJzEhqfcpyh0L7HLwYcYopK13Dbmuf+oUyu56/RoeB1nLnltH1VMQVj8v3Am2IwlGR+/JpFyrdkErN+cA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-sdk-s3": "3.888.0",
+        "@aws-sdk/types": "3.887.0",
+        "@smithy/protocol-http": "^5.2.1",
+        "@smithy/signature-v4": "^5.1.3",
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.888.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.888.0.tgz",
+      "integrity": "sha512-WA3NF+3W8GEuCMG1WvkDYbB4z10G3O8xuhT7QSjhvLYWQ9CPt3w4VpVIfdqmUn131TCIbhCzD0KN/1VJTjAjyw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.888.0",
+        "@aws-sdk/nested-clients": "3.888.0",
+        "@aws-sdk/types": "3.887.0",
+        "@smithy/property-provider": "^4.0.5",
+        "@smithy/shared-ini-file-loader": "^4.0.5",
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.887.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.887.0.tgz",
+      "integrity": "sha512-fmTEJpUhsPsovQ12vZSpVTEP/IaRoJAMBGQXlQNjtCpkBp6Iq3KQDa/HDaPINE+3xxo6XvTdtibsNOd5zJLV9A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-arn-parser": {
+      "version": "3.873.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.873.0.tgz",
+      "integrity": "sha512-qag+VTqnJWDn8zTAXX4wiVioa0hZDQMtbZcGRERVnLar4/3/VIKBhxX2XibNQXFu1ufgcRn4YntT/XEPecFWcg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.887.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.887.0.tgz",
+      "integrity": "sha512-kpegvT53KT33BMeIcGLPA65CQVxLUL/C3gTz9AzlU/SDmeusBHX4nRApAicNzI/ltQ5lxZXbQn18UczzBuwF1w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.887.0",
+        "@smithy/types": "^4.5.0",
+        "@smithy/url-parser": "^4.1.1",
+        "@smithy/util-endpoints": "^3.1.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-format-url": {
+      "version": "3.887.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.887.0.tgz",
+      "integrity": "sha512-ABDSP6KsrdD+JC7qwMqUpLXqPidvfgT+Q+W8sGGuk/IBy7smgZDOdYSZLE4VBbQpH3N/zSJuslAWhL2x37Qwww==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.887.0",
+        "@smithy/querystring-builder": "^4.1.1",
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.873.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.873.0.tgz",
+      "integrity": "sha512-xcVhZF6svjM5Rj89T1WzkjQmrTF6dpR2UvIHPMTnSZoNe6CixejPZ6f0JJ2kAhO8H+dUHwNBlsUgOTIKiK/Syg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.887.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.887.0.tgz",
+      "integrity": "sha512-X71UmVsYc6ZTH4KU6hA5urOzYowSXc3qvroagJNLJYU1ilgZ529lP4J9XOYfEvTXkLR1hPFSRxa43SrwgelMjA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.887.0",
+        "@smithy/types": "^4.5.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.888.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.888.0.tgz",
+      "integrity": "sha512-rSB3OHyuKXotIGfYEo//9sU0lXAUrTY28SUUnxzOGYuQsAt0XR5iYwBAp+RjV6x8f+Hmtbg0PdCsy1iNAXa0UQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-user-agent": "3.888.0",
+        "@aws-sdk/types": "3.887.0",
+        "@smithy/node-config-provider": "^4.2.1",
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.887.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.887.0.tgz",
+      "integrity": "sha512-lMwgWK1kNgUhHGfBvO/5uLe7TKhycwOn3eRCqsKPT9aPCx/HWuTlpcQp8oW2pCRGLS7qzcxqpQulcD+bbUL7XQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws/lambda-invoke-store": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.0.1.tgz",
+      "integrity": "sha512-ORHRQ2tmvnBXc8t/X9Z8IcSbBA4xTLKuN873FopzklHMeqBst7YG0d+AX97inkvDX+NChYtSr+qGfcqGFaI8Zw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
     },
     "node_modules/@babel/code-frame": {
       "version": "7.27.1",
@@ -2032,6 +2957,728 @@
         "@sinonjs/commons": "^3.0.0"
       }
     },
+    "node_modules/@smithy/abort-controller": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.1.1.tgz",
+      "integrity": "sha512-vkzula+IwRvPR6oKQhMYioM3A/oX/lFCZiwuxkQbRhqJS2S4YRY2k7k/SyR2jMf3607HLtbEwlRxi0ndXHMjRg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/chunked-blob-reader": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader/-/chunked-blob-reader-5.1.0.tgz",
+      "integrity": "sha512-a36AtR7Q7XOhRPt6F/7HENmTWcB8kN7mDJcOFM/+FuKO6x88w8MQJfYCufMWh4fGyVkPjUh3Rrz/dnqFQdo6OQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/chunked-blob-reader-native": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader-native/-/chunked-blob-reader-native-4.1.0.tgz",
+      "integrity": "sha512-Bnv0B3nSlfB2mPO0WgM49I/prl7+kamF042rrf3ezJ3Z4C7csPYvyYgZfXTGXwXfj1mAwDWjE/ybIf49PzFzvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-base64": "^4.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/config-resolver": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.2.1.tgz",
+      "integrity": "sha512-FXil8q4QN7mgKwU2hCLm0ltab8NyY/1RiqEf25Jnf6WLS3wmb11zGAoLETqg1nur2Aoibun4w4MjeN9CMJ4G6A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.2.1",
+        "@smithy/types": "^4.5.0",
+        "@smithy/util-config-provider": "^4.1.0",
+        "@smithy/util-middleware": "^4.1.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/core": {
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.11.0.tgz",
+      "integrity": "sha512-Abs5rdP1o8/OINtE49wwNeWuynCu0kme1r4RI3VXVrHr4odVDG7h7mTnw1WXXfN5Il+c25QOnrdL2y56USfxkA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/middleware-serde": "^4.1.1",
+        "@smithy/protocol-http": "^5.2.1",
+        "@smithy/types": "^4.5.0",
+        "@smithy/util-base64": "^4.1.0",
+        "@smithy/util-body-length-browser": "^4.1.0",
+        "@smithy/util-middleware": "^4.1.1",
+        "@smithy/util-stream": "^4.3.1",
+        "@smithy/util-utf8": "^4.1.0",
+        "@types/uuid": "^9.0.1",
+        "tslib": "^2.6.2",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.1.1.tgz",
+      "integrity": "sha512-1WdBfM9DwA59pnpIizxnUvBf/de18p4GP+6zP2AqrlFzoW3ERpZaT4QueBR0nS9deDMaQRkBlngpVlnkuuTisQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.2.1",
+        "@smithy/property-provider": "^4.1.1",
+        "@smithy/types": "^4.5.0",
+        "@smithy/url-parser": "^4.1.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-codec": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-4.1.1.tgz",
+      "integrity": "sha512-PwkQw1hZwHTQB6X5hSUWz2OSeuj5Z6enWuAqke7DgWoP3t6vg3ktPpqPz3Erkn6w+tmsl8Oss6nrgyezoea2Iw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@smithy/types": "^4.5.0",
+        "@smithy/util-hex-encoding": "^4.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-browser": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-4.1.1.tgz",
+      "integrity": "sha512-Q9QWdAzRaIuVkefupRPRFAasaG/droBqn1feiMnmLa+LLEUG45pqX1+FurHFmlqiCfobB3nUlgoJfeXZsr7MPA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/eventstream-serde-universal": "^4.1.1",
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-config-resolver": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-4.2.1.tgz",
+      "integrity": "sha512-oSUkF9zDN9zcOUBMtxp8RewJlh71E9NoHWU8jE3hU9JMYCsmW4assVTpgic/iS3/dM317j6hO5x18cc3XrfvEw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-node": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-4.1.1.tgz",
+      "integrity": "sha512-tn6vulwf/ScY0vjhzptSJuDJJqlhNtUjkxJ4wiv9E3SPoEqTEKbaq6bfqRO7nvhTG29ALICRcvfFheOUPl8KNA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/eventstream-serde-universal": "^4.1.1",
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-universal": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-4.1.1.tgz",
+      "integrity": "sha512-uLOAiM/Dmgh2CbEXQx+6/ssK7fbzFhd+LjdyFxXid5ZBCbLHTFHLdD/QbXw5aEDsLxQhgzDxLLsZhsftAYwHJA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/eventstream-codec": "^4.1.1",
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.2.1.tgz",
+      "integrity": "sha512-5/3wxKNtV3wO/hk1is+CZUhL8a1yy/U+9u9LKQ9kZTkMsHaQjJhc3stFfiujtMnkITjzWfndGA2f7g9Uh9vKng==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.2.1",
+        "@smithy/querystring-builder": "^4.1.1",
+        "@smithy/types": "^4.5.0",
+        "@smithy/util-base64": "^4.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/hash-blob-browser": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-blob-browser/-/hash-blob-browser-4.1.1.tgz",
+      "integrity": "sha512-avAtk++s1e/1VODf+rg7c9R2pB5G9y8yaJaGY4lPZI2+UIqVyuSDMikWjeWfBVmFZ3O7NpDxBbUCyGhThVUKWQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/chunked-blob-reader": "^5.1.0",
+        "@smithy/chunked-blob-reader-native": "^4.1.0",
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/hash-node": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.1.1.tgz",
+      "integrity": "sha512-H9DIU9WBLhYrvPs9v4sYvnZ1PiAI0oc8CgNQUJ1rpN3pP7QADbTOUjchI2FB764Ub0DstH5xbTqcMJu1pnVqxA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.5.0",
+        "@smithy/util-buffer-from": "^4.1.0",
+        "@smithy/util-utf8": "^4.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/hash-stream-node": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-stream-node/-/hash-stream-node-4.1.1.tgz",
+      "integrity": "sha512-3ztT4pV0Moazs3JAYFdfKk11kYFDo4b/3R3+xVjIm6wY9YpJf+xfz+ocEnNKcWAdcmSMqi168i2EMaKmJHbJMA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.5.0",
+        "@smithy/util-utf8": "^4.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/invalid-dependency": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.1.1.tgz",
+      "integrity": "sha512-1AqLyFlfrrDkyES8uhINRlJXmHA2FkG+3DY8X+rmLSqmFwk3DJnvhyGzyByPyewh2jbmV+TYQBEfngQax8IFGg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/is-array-buffer": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.1.0.tgz",
+      "integrity": "sha512-ePTYUOV54wMogio+he4pBybe8fwg4sDvEVDBU8ZlHOZXbXK3/C0XfJgUCu6qAZcawv05ZhZzODGUerFBPsPUDQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/md5-js": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/md5-js/-/md5-js-4.1.1.tgz",
+      "integrity": "sha512-MvWXKK743BuHjr/hnWuT6uStdKEaoqxHAQUvbKJPPZM5ZojTNFI5D+47BoQfBE5RgGlRRty05EbWA+NXDv+hIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.5.0",
+        "@smithy/util-utf8": "^4.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-content-length": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.1.1.tgz",
+      "integrity": "sha512-9wlfBBgTsRvC2JxLJxv4xDGNBrZuio3AgSl0lSFX7fneW2cGskXTYpFxCdRYD2+5yzmsiTuaAJD1Wp7gWt9y9w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.2.1",
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-endpoint": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.2.1.tgz",
+      "integrity": "sha512-fUTMmQvQQZakXOuKizfu7fBLDpwvWZjfH6zUK2OLsoNZRZGbNUdNSdLJHpwk1vS208jtDjpUIskh+JoA8zMzZg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.11.0",
+        "@smithy/middleware-serde": "^4.1.1",
+        "@smithy/node-config-provider": "^4.2.1",
+        "@smithy/shared-ini-file-loader": "^4.1.1",
+        "@smithy/types": "^4.5.0",
+        "@smithy/url-parser": "^4.1.1",
+        "@smithy/util-middleware": "^4.1.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-retry": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.2.1.tgz",
+      "integrity": "sha512-JzfvjwSJXWRl7LkLgIRTUTd2Wj639yr3sQGpViGNEOjtb0AkAuYqRAHs+jSOI/LPC0ZTjmFVVtfrCICMuebexw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.2.1",
+        "@smithy/protocol-http": "^5.2.1",
+        "@smithy/service-error-classification": "^4.1.1",
+        "@smithy/smithy-client": "^4.6.1",
+        "@smithy/types": "^4.5.0",
+        "@smithy/util-middleware": "^4.1.1",
+        "@smithy/util-retry": "^4.1.1",
+        "@types/uuid": "^9.0.1",
+        "tslib": "^2.6.2",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-serde": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.1.1.tgz",
+      "integrity": "sha512-lh48uQdbCoj619kRouev5XbWhCwRKLmphAif16c4J6JgJ4uXjub1PI6RL38d3BLliUvSso6klyB/LTNpWSNIyg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.2.1",
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-stack": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.1.1.tgz",
+      "integrity": "sha512-ygRnniqNcDhHzs6QAPIdia26M7e7z9gpkIMUe/pK0RsrQ7i5MblwxY8078/QCnGq6AmlUUWgljK2HlelsKIb/A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-config-provider": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.2.1.tgz",
+      "integrity": "sha512-AIA0BJZq2h295J5NeCTKhg1WwtdTA/GqBCaVjk30bDgMHwniUETyh5cP9IiE9VrId7Kt8hS7zvREVMTv1VfA6g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/property-provider": "^4.1.1",
+        "@smithy/shared-ini-file-loader": "^4.1.1",
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.2.1.tgz",
+      "integrity": "sha512-REyybygHlxo3TJICPF89N2pMQSf+p+tBJqpVe1+77Cfi9HBPReNjTgtZ1Vg73exq24vkqJskKDpfF74reXjxfw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/abort-controller": "^4.1.1",
+        "@smithy/protocol-http": "^5.2.1",
+        "@smithy/querystring-builder": "^4.1.1",
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/property-provider": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.1.1.tgz",
+      "integrity": "sha512-gm3ZS7DHxUbzC2wr8MUCsAabyiXY0gaj3ROWnhSx/9sPMc6eYLMM4rX81w1zsMaObj2Lq3PZtNCC1J6lpEY7zg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/protocol-http": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.2.1.tgz",
+      "integrity": "sha512-T8SlkLYCwfT/6m33SIU/JOVGNwoelkrvGjFKDSDtVvAXj/9gOT78JVJEas5a+ETjOu4SVvpCstKgd0PxSu/aHw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-builder": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.1.1.tgz",
+      "integrity": "sha512-J9b55bfimP4z/Jg1gNo+AT84hr90p716/nvxDkPGCD4W70MPms0h8KF50RDRgBGZeL83/u59DWNqJv6tEP/DHA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.5.0",
+        "@smithy/util-uri-escape": "^4.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-parser": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.1.1.tgz",
+      "integrity": "sha512-63TEp92YFz0oQ7Pj9IuI3IgnprP92LrZtRAkE3c6wLWJxfy/yOPRt39IOKerVr0JS770olzl0kGafXlAXZ1vng==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/service-error-classification": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.1.1.tgz",
+      "integrity": "sha512-Iam75b/JNXyDE41UvrlM6n8DNOa/r1ylFyvgruTUx7h2Uk7vDNV9AAwP1vfL1fOL8ls0xArwEGVcGZVd7IO/Cw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.5.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/shared-ini-file-loader": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.1.1.tgz",
+      "integrity": "sha512-YkpikhIqGc4sfXeIbzSj10t2bJI/sSoP5qxLue6zG+tEE3ngOBSm8sO3+djacYvS/R5DfpxN/L9CyZsvwjWOAQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.2.1.tgz",
+      "integrity": "sha512-M9rZhWQLjlQVCCR37cSjHfhriGRN+FQ8UfgrYNufv66TJgk+acaggShl3KS5U/ssxivvZLlnj7QH2CUOKlxPyA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^4.1.0",
+        "@smithy/protocol-http": "^5.2.1",
+        "@smithy/types": "^4.5.0",
+        "@smithy/util-hex-encoding": "^4.1.0",
+        "@smithy/util-middleware": "^4.1.1",
+        "@smithy/util-uri-escape": "^4.1.0",
+        "@smithy/util-utf8": "^4.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/smithy-client": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.6.1.tgz",
+      "integrity": "sha512-WolVLDb9UTPMEPPOncrCt6JmAMCSC/V2y5gst2STWJ5r7+8iNac+EFYQnmvDCYMfOLcilOSEpm5yXZXwbLak1Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.11.0",
+        "@smithy/middleware-endpoint": "^4.2.1",
+        "@smithy/middleware-stack": "^4.1.1",
+        "@smithy/protocol-http": "^5.2.1",
+        "@smithy/types": "^4.5.0",
+        "@smithy/util-stream": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.5.0.tgz",
+      "integrity": "sha512-RkUpIOsVlAwUIZXO1dsz8Zm+N72LClFfsNqf173catVlvRZiwPy0x2u0JLEA4byreOPKDZPGjmPDylMoP8ZJRg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/url-parser": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.1.1.tgz",
+      "integrity": "sha512-bx32FUpkhcaKlEoOMbScvc93isaSiRM75pQ5IgIBaMkT7qMlIibpPRONyx/0CvrXHzJLpOn/u6YiDX2hcvs7Dg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/querystring-parser": "^4.1.1",
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-base64": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.1.0.tgz",
+      "integrity": "sha512-RUGd4wNb8GeW7xk+AY5ghGnIwM96V0l2uzvs/uVHf+tIuVX2WSvynk5CxNoBCsM2rQRSZElAo9rt3G5mJ/gktQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^4.1.0",
+        "@smithy/util-utf8": "^4.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-body-length-browser": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.1.0.tgz",
+      "integrity": "sha512-V2E2Iez+bo6bUMOTENPr6eEmepdY8Hbs+Uc1vkDKgKNA/brTJqOW/ai3JO1BGj9GbCeLqw90pbbH7HFQyFotGQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-body-length-node": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.1.0.tgz",
+      "integrity": "sha512-BOI5dYjheZdgR9XiEM3HJcEMCXSoqbzu7CzIgYrx0UtmvtC3tC2iDGpJLsSRFffUpy8ymsg2ARMP5fR8mtuUQQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-buffer-from": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.1.0.tgz",
+      "integrity": "sha512-N6yXcjfe/E+xKEccWEKzK6M+crMrlwaCepKja0pNnlSkm6SjAeLKKA++er5Ba0I17gvKfN/ThV+ZOx/CntKTVw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^4.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-config-provider": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.1.0.tgz",
+      "integrity": "sha512-swXz2vMjrP1ZusZWVTB/ai5gK+J8U0BWvP10v9fpcFvg+Xi/87LHvHfst2IgCs1i0v4qFZfGwCmeD/KNCdJZbQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-defaults-mode-browser": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.1.1.tgz",
+      "integrity": "sha512-hA1AKIHFUMa9Tl6q6y8p0pJ9aWHCCG8s57flmIyLE0W7HcJeYrYtnqXDcGnftvXEhdQnSexyegXnzzTGk8bKLA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/property-provider": "^4.1.1",
+        "@smithy/smithy-client": "^4.6.1",
+        "@smithy/types": "^4.5.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-defaults-mode-node": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.1.1.tgz",
+      "integrity": "sha512-RGSpmoBrA+5D2WjwtK7tto6Pc2wO9KSXKLpLONhFZ8VyuCbqlLdiDAfuDTNY9AJe4JoE+Cx806cpTQQoQ71zPQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/config-resolver": "^4.2.1",
+        "@smithy/credential-provider-imds": "^4.1.1",
+        "@smithy/node-config-provider": "^4.2.1",
+        "@smithy/property-provider": "^4.1.1",
+        "@smithy/smithy-client": "^4.6.1",
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-endpoints": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.1.1.tgz",
+      "integrity": "sha512-qB4R9kO0SetA11Rzu6MVGFIaGYX3p6SGGGfWwsKnC6nXIf0n/0AKVwRTsYsz9ToN8CeNNtNgQRwKFBndGJZdyw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.2.1",
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-hex-encoding": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.1.0.tgz",
+      "integrity": "sha512-1LcueNN5GYC4tr8mo14yVYbh/Ur8jHhWOxniZXii+1+ePiIbsLZ5fEI0QQGtbRRP5mOhmooos+rLmVASGGoq5w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-middleware": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.1.1.tgz",
+      "integrity": "sha512-CGmZ72mL29VMfESz7S6dekqzCh8ZISj3B+w0g1hZFXaOjGTVaSqfAEFAq8EGp8fUL+Q2l8aqNmt8U1tglTikeg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-retry": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.1.1.tgz",
+      "integrity": "sha512-jGeybqEZ/LIordPLMh5bnmnoIgsqnp4IEimmUp5c5voZ8yx+5kAlN5+juyr7p+f7AtZTgvhmInQk4Q0UVbrZ0Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/service-error-classification": "^4.1.1",
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-stream": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.3.1.tgz",
+      "integrity": "sha512-khKkW/Jqkgh6caxMWbMuox9+YfGlsk9OnHOYCGVEdYQb/XVzcORXHLYUubHmmda0pubEDncofUrPNniS9d+uAA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/fetch-http-handler": "^5.2.1",
+        "@smithy/node-http-handler": "^4.2.1",
+        "@smithy/types": "^4.5.0",
+        "@smithy/util-base64": "^4.1.0",
+        "@smithy/util-buffer-from": "^4.1.0",
+        "@smithy/util-hex-encoding": "^4.1.0",
+        "@smithy/util-utf8": "^4.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-uri-escape": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.1.0.tgz",
+      "integrity": "sha512-b0EFQkq35K5NHUYxU72JuoheM6+pytEVUGlTwiFxWFpmddA+Bpz3LgsPRIpBk8lnPE47yT7AF2Egc3jVnKLuPg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-utf8": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.1.0.tgz",
+      "integrity": "sha512-mEu1/UIXAdNYuBcyEPbjScKi/+MQVXNIuY/7Cm5XLIWe319kDrT5SizBE95jqtmEXoDbGoZxKLCMttdZdqTZKQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^4.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-waiter": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-4.1.1.tgz",
+      "integrity": "sha512-PJBmyayrlfxM7nbqjomF4YcT1sApQwZio0NHSsT0EzhJqljRmvhzqZua43TyEs80nJk2Cn2FGPg/N8phH6KeCQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/abort-controller": "^4.1.1",
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@testing-library/dom": {
       "version": "10.4.1",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
@@ -2569,6 +4216,12 @@
       "dependencies": {
         "@types/superagent": "*"
       }
+    },
+    "node_modules/@types/uuid": {
+      "version": "9.0.8",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
+      "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==",
+      "license": "MIT"
     },
     "node_modules/@types/yargs": {
       "version": "17.0.33",
@@ -3220,6 +4873,12 @@
           "url": "https://opencollective.com/bootstrap"
         }
       ],
+      "license": "MIT"
+    },
+    "node_modules/bowser": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.12.1.tgz",
+      "integrity": "sha512-z4rE2Gxh7tvshQ4hluIT7XcFrgLIQaw9X3A+kTTRdovCz5PMukm/0QC/BKSYPj3omF5Qfypn9O/c5kgpmvYUCw==",
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
@@ -4362,6 +6021,24 @@
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.2.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.2.5.tgz",
+      "integrity": "sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "strnum": "^2.1.0"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
     },
     "node_modules/fb-watchman": {
       "version": "2.0.2",
@@ -7764,6 +9441,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/strnum": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.1.tgz",
+      "integrity": "sha512-7ZvoFTiCnGxBtDqJ//Cu6fWtZtc7Y3x+QOirG15wztbdngGSkht27o2pyGWrVy0b4WAy3jbKmnoK6g5VlVNUUw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/superagent": {
       "version": "8.1.2",
       "resolved": "https://registry.npmjs.org/superagent/-/superagent-8.1.2.tgz",
@@ -8208,7 +9897,6 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
       "license": "0BSD"
     },
     "node_modules/type-detect": {
@@ -8368,6 +10056,19 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/v8-compile-cache-lib": {

--- a/specs/ParentDashboardMobile.md
+++ b/specs/ParentDashboardMobile.md
@@ -1,0 +1,264 @@
+# Parent Dashboard – Mobile Guidelines (S ≤ 640px)
+
+This document translates the provided mobile-UX guidance into actionable, stack-aligned specs for the Parent Dashboard. The web app uses React + Bootstrap (via utility classes and simple custom CSS tokens). Tailwind snippets from the source context are preserved conceptually and mapped to Bootstrap-friendly patterns below.
+
+## Mobile UX Goals
+- No horizontal scroll on pages or key panes.
+- Clear navigation via hamburger + off-canvas drawer.
+- Wide tables collapse into stacked cards on small screens.
+- “Week” views show one day at a time (pager) on small screens; full 7-day grid on md+.
+- Primary actions are easy to reach (sticky bottom bar or FAB).
+
+## Global Layout
+- Wrap dashboard pages in a top bar + main stack layout.
+- Prevent accidental horizontal scroll:
+  - Add `html, body { overflow-x: hidden; }` in global CSS if not already present.
+  - Use Bootstrap’s `text-wrap`/`text-break` (or `word-break: break-word; overflow-wrap: anywhere;`) on long strings.
+- Spacing: vertical sections separated by ~16px (`.mb-3`/`.mb-4`) and container padding.
+
+## AppShell & Drawer (Bootstrap-oriented)
+- Top bar: title + hamburger. On md+, show inline actions; on small screens, show hamburger only.
+- Off-canvas drawer: navigation links to Family, Parents, Children, Chores, Approvals, Week.
+- Implementation options:
+  - Use Bootstrap Offcanvas component; or
+  - Use a simple custom aside + overlay (pattern already used in ChildDashboard) with `position: fixed`, translating X with CSS.
+
+Example sketch (React):
+
+```tsx
+// Pseudocode – align styles with existing TopBar and sidebar pattern
+function AppShell({ children }: { children: React.ReactNode }) {
+  const [open, setOpen] = React.useState(false);
+  return (
+    <div>
+      <div className="cc-topbar border-bottom" style={{ background: 'var(--surface)' }}>
+        <div className="container d-flex align-items-center justify-content-between py-2">
+          <button className="btn btn-link p-0 d-md-none" aria-label="Open menu" onClick={()=>setOpen(true)}>
+            <span aria-hidden>≡</span>
+          </button>
+          <h1 className="h6 mb-0">Parent Dashboard</h1>
+          <div className="d-none d-md-flex align-items-center gap-2">
+            {/* desktop actions here */}
+          </div>
+        </div>
+      </div>
+
+      {/* Off-canvas */}
+      {open && <div role="button" aria-label="Close" onClick={()=>setOpen(false)} style={{ position:'fixed', inset:0, background:'rgba(0,0,0,0.4)', zIndex:1040 }} />}
+      <aside aria-label="Main" style={{ position:'fixed', top:0, bottom:0, left:0, width:280, background:'var(--surface)', borderRight:'1px solid var(--border)', transform: open ? 'translateX(0)' : 'translateX(-100%)', transition:'transform 150ms ease', zIndex:1050 }}>
+        <div className="p-3">
+          <button className="btn btn-sm btn-outline-secondary mb-3" onClick={()=>setOpen(false)} aria-label="Close menu">Close</button>
+          {['Family','Parents','Children','Chores','Approvals','Week'].map((item) => (
+            <a key={item} href={`#${item.toLowerCase()}`} className="d-block text-decoration-none py-2">{item}</a>
+          ))}
+        </div>
+      </aside>
+
+      <main className="container py-3">
+        {children}
+      </main>
+    </div>
+  );
+}
+```
+
+## Children & Chores: Table → Stacked Cards
+- On md+, keep tables for density and scanning.
+- On small screens, render stacked cards and hide tables to avoid horizontal scrolling.
+- Use Bootstrap visibility utilities:
+  - Cards shown on small only: `d-block d-md-none`
+  - Table shown md+: `d-none d-md-block`
+- Compact actions on mobile: arrange `+ Credit`, `– Debit`, `Rename`, `Delete` into a 2×2 grid or use a small “More” menu.
+
+Example (mobile card):
+
+```tsx
+// Inside ParentDashboard children section
+<section className="d-block d-md-none">
+  {children.map((c: any) => (
+    <div key={c.id} className="card mb-2 shadow-sm">
+      <div className="card-body">
+        <div className="d-flex justify-content-between align-items-start">
+          <div>
+            <div className="fw-semibold">{c.displayName}</div>
+            <div className="text-muted small">@{c.username}</div>
+          </div>
+          <span className="small fw-medium">Total: {(balances[c.id]?.available ?? 0)+(balances[c.id]?.reserved ?? 0)}</span>
+        </div>
+        <div className="row row-cols-2 g-2 small mt-2">
+          <div><span className="text-muted">Available</span> <span>{balances[c.id]?.available ?? 0}</span></div>
+          <div><span className="text-muted">Allocated</span> <span>{balances[c.id]?.reserved ?? 0}</span></div>
+        </div>
+        <div className="row row-cols-2 g-2 mt-2">
+          <button className="btn btn-outline-success btn-sm">+ Credit</button>
+          <button className="btn btn-outline-danger btn-sm">– Debit</button>
+          <button className="btn btn-outline-secondary btn-sm">Rename</button>
+          <button className="btn btn-outline-secondary btn-sm text-danger">Delete</button>
+        </div>
+      </div>
+    </div>
+  ))}
+  
+</section>
+
+<div className="d-none d-md-block table-responsive">
+  {/* existing table here */}
+  
+</div>
+```
+
+## Approvals & Primary Actions: Sticky Bar (Mobile)
+- On small screens, anchor primary actions in a bottom sticky bar.
+- Style: subtle border-top, blurred/opaque white background, safe tap targets.
+
+Example:
+
+```tsx
+function StickyActions() {
+  return (
+    <div className="d-md-none" style={{ position:'fixed', bottom:0, left:0, right:0, zIndex:1040, background:'rgba(255,255,255,0.95)', backdropFilter:'blur(6px)', borderTop:'1px solid var(--border)' }}>
+      <div className="container py-2 d-flex gap-2">
+        <button className="btn btn-primary w-100">Run payout</button>
+        <button className="btn btn-outline-secondary" style={{ minWidth: 120 }}>Add child</button>
+      </div>
+    </div>
+  );
+}
+```
+
+## Week Overview: 7 Columns → Day Pager (Mobile)
+- Small screens: show a single day with prev/next chevrons; list each child’s progress for that day.
+- md+: keep the full 7-column grid.
+
+Example:
+
+```tsx
+function WeekOverviewMobile({ data }: { data: { children: any[]; days: string[]; progress: Record<string, string[]> } }) {
+  const [dayIndex, setDayIndex] = React.useState(0);
+  return (
+    <section className="card d-block d-md-none">
+      <div className="card-body">
+        <div className="d-flex justify-content-between align-items-center border-bottom pb-2 mb-2">
+          <button className="btn btn-link p-0" aria-label="Prev" onClick={()=>setDayIndex((d)=> (d+6)%7)}>‹</button>
+          <div className="fw-semibold">{data.days[dayIndex]}</div>
+          <button className="btn btn-link p-0" aria-label="Next" onClick={()=>setDayIndex((d)=> (d+1)%7)}>›</button>
+        </div>
+        <ul className="list-unstyled mb-0">
+          {data.children.map((c) => (
+            <li key={c.id} className="d-flex justify-content-between py-2 border-bottom">
+              <span>{c.name}</span>
+              <span className="text-muted small">{data.progress[c.id][dayIndex]}</span>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </section>
+  );
+}
+```
+
+## Week Details: Collapsible per Child (Mobile)
+- Each child’s weekly details are an accordion/disclosure.
+- Tap row to expand; show day tiles with chore badges.
+
+Example:
+
+```tsx
+function WeekDetailsItem({ child }: { child: any }) {
+  const [open, setOpen] = React.useState(false);
+  return (
+    <div className="card mb-2">
+      <button className="btn text-start w-100 px-3 py-2 d-flex justify-content-between align-items-center" onClick={()=>setOpen(o=>!o)} aria-expanded={open}>
+        <span className="fw-semibold">{child.name}</span>
+        <span className="text-muted small">Coins: {child.coins} / {child.weekTotal}</span>
+      </button>
+      {open && (
+        <div className="px-3 pb-3">
+          <div className="row row-cols-2 row-cols-sm-3 g-2">
+            {child.days.map((d: any) => (
+              <div key={d.day} className="border rounded p-2">
+                <div className="text-muted small">{d.day}</div>
+                {d.items.map((it: any) => (
+                  <div key={it.id} className="mt-1 small">
+                    {it.name}
+                    <span className="ms-1 badge bg-light text-dark">+{it.value}</span>
+                    {it.status === 'Due' ? (
+                      <span className="ms-2 text-danger small">Due</span>
+                    ) : (
+                      <span className="ms-2 text-success small">{it.status}</span>
+                    )}
+                  </div>
+                ))}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+```
+
+## Chores Editor: Responsive Form
+- Single column on small screens; two columns on md+ using Bootstrap grid.
+- “Assign to” chips should wrap on small screens.
+
+Example:
+
+```tsx
+<form className="row g-3">
+  <div className="col-12 col-md-6">
+    <label className="form-label">Name</label>
+    <input className="form-control" />
+  </div>
+  <div className="col-12 col-md-6">
+    <label className="form-label">Recurrence</label>
+    <select className="form-select"><option>Daily</option><option>Weekly</option></select>
+  </div>
+  <div className="col-12">
+    <label className="form-label">Assign to</label>
+    <div className="d-flex flex-wrap gap-2">
+      {/* map children to pill checkboxes */}
+      <label className="border rounded-pill px-3 py-1 d-inline-flex align-items-center gap-2">
+        <input type="checkbox" className="form-check-input m-0" /> Alex
+      </label>
+    </div>
+  </div>
+  <div className="col-12 d-flex justify-content-end gap-2">
+    <button className="btn btn-primary">Save chore</button>
+  </div>
+  
+</form>
+```
+
+## Accessibility & Tap Targets
+- Minimum touch target: 44×44px for primary controls; avoid tiny icon-only buttons without labels on mobile.
+- Use `aria-expanded`, `aria-controls` for collapsibles; maintain visible focus rings for keyboard users.
+- Provide text labels next to icons for clarity on small screens.
+
+## Performance & Polish
+- Lazy-render expanded content in Week Details (render lists only when open).
+- Consider `content-visibility: auto` on long lists/sections.
+- Typography that scales reasonably on mobile (e.g., avoid very small text; use Bootstrap’s `.small` sparingly).
+
+## Utility Cheatsheet (Bootstrap)
+- Visibility: `d-none d-md-block` (desktop only), `d-block d-md-none` (mobile only).
+- Tables: wrap with `.table-responsive` to avoid page-level scroll; prefer cards on small.
+- Text wrapping: `.text-wrap`, `.text-break`, or custom CSS `overflow-wrap: anywhere`.
+- Sticky actions: fixed bottom container with border-top and blurred/opaque background.
+
+## Acceptance Checklist
+- App shell with sticky header + off-canvas drawer (hamburger visible on `md` and below).
+- No horizontal scrolling; long text wraps.
+- Children & Chores render stacked cards on mobile; tables remain on md+.
+- Per-row actions condensed for mobile (grid or “More” menu).
+- Week Overview uses a day pager on small; full 7-column grid on md+.
+- Week Details collapsible per child with chore badges.
+- Sticky bottom action bar (mobile) for primary actions (e.g., Run payout, Add child).
+- Forms collapse to single column on small; chips wrap.
+- A11y attributes and 44px tap targets included.
+- Lazy-render expanded content; consider `content-visibility: auto` for long lists.
+
+---
+Notes:
+- The Tailwind-based snippets in the original guidance map 1:1 to these behaviors. If we introduce Tailwind later, we can lift those directly; for now, Bootstrap utilities achieve the same UX.

--- a/specs/UIImplementationPlan.md
+++ b/specs/UIImplementationPlan.md
@@ -115,3 +115,35 @@ Deliverables & Definition of Done
 - Accessibility: focus, labels, and contrast meet guidelines; reduced motion respected.
 - Visual QA against reference (soft cards, rounded corners, airy spacing, friendly typography).
 
+## Parent Dashboard – Mobile Guidelines (Link + Tasks)
+
+Reference: see specs/ParentDashboardMobile.md for detailed UX and example snippets adapted to our Bootstrap stack.
+
+Implementation Tasks (Ticket Out)
+1) Global no-x-scroll and wrapping
+   - Add `overflow-x: hidden` to html/body; ensure long text wraps (`.text-wrap`/`.text-break`).
+2) AppShell + Off-canvas drawer
+   - Add sticky header with hamburger on small screens; off-canvas nav with routes: Family, Parents, Children, Chores, Approvals, Week.
+3) Children & Chores responsive rendering
+   - Render stacked cards on small screens (`d-block d-md-none`); keep existing tables on md+ (`d-none d-md-block`).
+   - Replace per-row sprawl with compact 2×2 grid of actions or a ‘More’ menu on mobile.
+4) Approvals primary actions
+   - Add sticky bottom action bar on mobile for “Run payout” and “Add child”.
+5) Week Overview (mobile pager)
+   - On small screens, show one day at a time with prev/next; md+ keeps 7-column grid.
+6) Week Details (accordion)
+   - Convert per-child weekly details into collapsible cards on mobile; include status badges and values.
+7) Chores editor responsive form
+   - Single column on small; two columns on md+. Ensure assigned-child chips wrap.
+8) Accessibility & tap targets
+   - Ensure 44×44px targets for primary buttons; add `aria-expanded` for disclosures; maintain visible focus rings.
+9) Performance polish
+   - Lazy-render expanded details; consider `content-visibility: auto` on long lists.
+
+Acceptance (matches spec)
+- No horizontal scroll; long text wraps.
+- Drawer/hamburger navigation works on mobile; desktop retains inline actions.
+- Children/Chores use cards on mobile and tables on md+; actions are reachable without overflow.
+- Week Overview uses day pager on small; Week Details use collapsible cards.
+- Sticky action bar present on mobile for key actions.
+- Forms are usable on mobile; chips wrap; A11y targets and attributes present.

--- a/web/src/components/TopBar.tsx
+++ b/web/src/components/TopBar.tsx
@@ -7,6 +7,7 @@ export default function TopBar({
   accent,
   onMenuToggle,
   onNameClick,
+  onAvatarClick,
   profileHref
 }: {
   name?: string | null;
@@ -15,6 +16,7 @@ export default function TopBar({
   accent?: string | null;
   onMenuToggle?: () => void;
   onNameClick?: () => void;
+  onAvatarClick?: () => void;
   profileHref?: string;
 }) {
   return (
@@ -37,9 +39,33 @@ export default function TopBar({
             </button>
           ) : null}
           {avatar ? (
-            <img src={avatar} alt="avatar" style={{ width: 28, height: 28, borderRadius: '50%' }} />
+            onAvatarClick ? (
+              <button
+                type="button"
+                className="btn btn-link p-0"
+                aria-label="Edit profile"
+                onClick={onAvatarClick}
+                style={{ lineHeight: 0 }}
+              >
+                <img src={avatar} alt="avatar" style={{ width: 28, height: 28, borderRadius: '50%' }} />
+              </button>
+            ) : (
+              <img src={avatar} alt="avatar" style={{ width: 28, height: 28, borderRadius: '50%' }} />
+            )
           ) : (
-            <div style={{ width: 28, height: 28, borderRadius: '50%', background: 'var(--primary-light)' }} />
+            onAvatarClick ? (
+              <button
+                type="button"
+                className="btn btn-link p-0"
+                aria-label="Edit profile"
+                onClick={onAvatarClick}
+                style={{ lineHeight: 0 }}
+              >
+                <div style={{ width: 28, height: 28, borderRadius: '50%', background: 'var(--primary-light)' }} />
+              </button>
+            ) : (
+              <div style={{ width: 28, height: 28, borderRadius: '50%', background: 'var(--primary-light)' }} />
+            )
           )}
           {onNameClick || profileHref ? (
             profileHref ? (

--- a/web/src/routes/ParentDashboard.tsx
+++ b/web/src/routes/ParentDashboard.tsx
@@ -277,7 +277,7 @@ export default function ParentDashboard() {
         </nav>
       </aside>
 
-      <div className="container py-4" style={{ paddingBottom: 72 }}>
+      <div className="container py-4" style={{ paddingBottom: 120 }}>
         <div className="d-flex align-items-center justify-content-between mb-3">
           <h1 className="h3 mb-0">Parent Dashboard</h1>
         </div>
@@ -1126,7 +1126,7 @@ export default function ParentDashboard() {
       <div className="d-md-none" style={{ position: 'fixed', bottom: 0, left: 0, right: 0, zIndex: 1040, background: 'rgba(255,255,255,0.95)', backdropFilter: 'blur(6px)', borderTop: '1px solid var(--border)' }}>
         <div className="container py-2 d-flex gap-2">
           <button className="btn btn-primary w-100" disabled={payoutBusy || !selectedFamily} onClick={runPayout}>{payoutBusy ? 'Paying…' : 'Run payout'}</button>
-          <button className="btn btn-outline-secondary" style={{ minWidth: 120 }} onClick={() => addChildRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' })}>Add child</button>
+          <button className="btn btn-outline-secondary" style={{ minWidth: 120 }} onClick={() => childrenRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' })}>Add Coins</button>
         </div>
       </div>
     </>

--- a/web/src/routes/ParentDashboard.tsx
+++ b/web/src/routes/ParentDashboard.tsx
@@ -27,6 +27,13 @@ export default function ParentDashboard() {
   const [detailsOpen, setDetailsOpen] = useState<Record<string, boolean>>({}); // mobile accordion for Week Details
   const hashToken = useMemo(() => new URLSearchParams(loc.hash.replace(/^#/, '')).get('token'), [loc.hash]);
   const addChildRef = useRef<HTMLDivElement | null>(null);
+  const familyRef = useRef<HTMLDivElement | null>(null);
+  const childrenRef = useRef<HTMLDivElement | null>(null);
+  const choresRef = useRef<HTMLDivElement | null>(null);
+  const approvalsRef = useRef<HTMLDivElement | null>(null);
+  const weekOverviewRef = useRef<HTMLDivElement | null>(null);
+  const weekDetailsRef = useRef<HTMLDivElement | null>(null);
+  const [menuOpen, setMenuOpen] = useState(false);
 
   useEffect(() => {
     const t = hashToken || localStorage.getItem('parentToken');
@@ -225,8 +232,52 @@ export default function ParentDashboard() {
 
   return (
     <>
-      <TopBar name={me?.name || me?.email || 'Parent'} avatar={null} onLogout={async () => { try { await fetch('/auth/logout', { method: 'POST' }); } catch {}; localStorage.removeItem('parentToken'); nav('/'); }} />
-      <div className="container py-4">
+      <TopBar
+        name={me?.name || me?.email || 'Parent'}
+        avatar={null}
+        onMenuToggle={() => setMenuOpen(true)}
+        onLogout={async () => { try { await fetch('/auth/logout', { method: 'POST' }); } catch {}; localStorage.removeItem('parentToken'); nav('/'); }}
+      />
+
+      {/* Off-canvas drawer */}
+      {menuOpen ? (
+        <div
+          role="button"
+          aria-label="Close menu"
+          onClick={() => setMenuOpen(false)}
+          style={{ position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.25)', zIndex: 1030 }}
+        />
+      ) : null}
+      <aside
+        aria-label="Navigation"
+        style={{ position: 'fixed', top: 0, bottom: 0, left: 0, width: 260, background: 'var(--surface)', borderRight: '1px solid var(--border)', transform: menuOpen ? 'translateX(0)' : 'translateX(-100%)', transition: 'transform 150ms ease', zIndex: 1040, padding: '16px' }}
+      >
+        <div className="d-flex justify-content-between align-items-center mb-3">
+          <div className="fw-semibold">Menu</div>
+          <button className="btn btn-sm btn-outline-secondary" onClick={() => setMenuOpen(false)} aria-label="Close menu">Close</button>
+        </div>
+        <nav className="nav flex-column">
+          {[
+            { label: 'Family', ref: familyRef },
+            { label: 'Add child', ref: addChildRef },
+            { label: 'Children', ref: childrenRef },
+            { label: 'Chores', ref: choresRef },
+            { label: 'Approvals', ref: approvalsRef },
+            { label: 'Week Overview', ref: weekOverviewRef },
+            { label: 'Week Details', ref: weekDetailsRef }
+          ].map((it) => (
+            <button
+              key={it.label}
+              className="btn btn-outline-secondary text-start mb-2"
+              onClick={() => { it.ref.current?.scrollIntoView({ behavior: 'smooth', block: 'start' }); setMenuOpen(false); }}
+            >
+              {it.label}
+            </button>
+          ))}
+        </nav>
+      </aside>
+
+      <div className="container py-4" style={{ paddingBottom: 72 }}>
         <div className="d-flex align-items-center justify-content-between mb-3">
           <h1 className="h3 mb-0">Parent Dashboard</h1>
         </div>
@@ -252,7 +303,7 @@ export default function ParentDashboard() {
       ) : (
         <div className="row g-4">
           <div className="col-md-6">
-          <div className="card h-100">
+          <div className="card h-100" ref={familyRef}>
             <div className="card-body">
               <h2 className="h5">Family</h2>
               <p className="mb-1"><strong>Name:</strong> {selectedFamily?.name}</p>
@@ -329,7 +380,7 @@ export default function ParentDashboard() {
             </div>
         </div>
           <div className="col-12">
-            <div className="card">
+            <div className="card" ref={childrenRef}>
               <div className="card-body">
                 <h2 className="h5">Children</h2>
                 {/* TODO(mobile): Render stacked cards on small screens; keep table on md+. See specs/ParentDashboardMobile.md */}
@@ -480,7 +531,7 @@ export default function ParentDashboard() {
             </div>
           </div>
           <div className="col-12">
-            <div className="card">
+            <div className="card" ref={choresRef}>
               <div className="card-body">
                 <h2 className="h5">Chores</h2>
                 {/* TODO(mobile): Make new/edit chore forms single-column on small; chips wrap. See spec */}
@@ -772,7 +823,7 @@ export default function ParentDashboard() {
             </div>
           </div>
           <div className="col-12">
-            <div className="card">
+            <div className="card" ref={approvalsRef}>
               <div className="card-body">
                 <h2 className="h5">Approvals</h2>
                 {/* TODO(mobile): Add sticky bottom action bar with Run payout / Add child on small screens */}
@@ -870,7 +921,7 @@ export default function ParentDashboard() {
             </div>
           </div>
           <div className="col-12">
-            <div className="card">
+            <div className="card" ref={weekOverviewRef}>
               <div className="card-body">
                 <h2 className="h5">Week Overview</h2>
                 {/* TODO(mobile): Replace 7-column grid with day pager on small; keep grid on md+ */}
@@ -951,7 +1002,7 @@ export default function ParentDashboard() {
             </div>
           </div>
           <div className="col-12">
-            <div className="card">
+            <div className="card" ref={weekDetailsRef}>
               <div className="card-body">
                 <h2 className="h5">Week Details</h2>
                 {children.length === 0 ? (

--- a/web/src/routes/ParentDashboard.tsx
+++ b/web/src/routes/ParentDashboard.tsx
@@ -256,7 +256,7 @@ export default function ParentDashboard() {
           <div className="fw-semibold">Menu</div>
           <button className="btn btn-sm btn-outline-secondary" onClick={() => setMenuOpen(false)} aria-label="Close menu">Close</button>
         </div>
-        <nav className="nav flex-column">
+        <nav className="nav flex-column" aria-label="Sections">
           {[
             { label: 'Family', ref: familyRef },
             { label: 'Add child', ref: addChildRef },
@@ -268,7 +268,7 @@ export default function ParentDashboard() {
           ].map((it) => (
             <button
               key={it.label}
-              className="btn btn-outline-secondary text-start mb-2"
+              className="btn btn-outline-secondary text-start mb-2 touch-target"
               onClick={() => { it.ref.current?.scrollIntoView({ behavior: 'smooth', block: 'start' }); setMenuOpen(false); }}
             >
               {it.label}
@@ -389,7 +389,7 @@ export default function ParentDashboard() {
                 ) : (
                   <>
                     {/* Mobile: stacked cards */}
-                    <section className="d-block d-md-none">
+                    <section className="d-block d-md-none" style={{ contentVisibility: 'auto' as any }}>
                       {children.map((c) => (
                         <div key={`child-card-${c.id}`} className="card mb-2 shadow-sm">
                           <div className="card-body">
@@ -712,7 +712,7 @@ export default function ParentDashboard() {
                 ) : (
                   <>
                     {/* Mobile: chore cards */}
-                    <div className="d-block d-md-none">
+                    <div className="d-block d-md-none" style={{ contentVisibility: 'auto' as any }}>
                       {chores.map((h) => {
                         const assigned = children.filter((c) => h.assignedChildIds?.includes(c.id)).map((c) => c.displayName).join(', ') || '-';
                         return (
@@ -1001,7 +1001,7 @@ export default function ParentDashboard() {
               </div>
             </div>
           </div>
-          <div className="col-12">
+          <div className="col-12 mobile-bottom">
             <div className="card" ref={weekDetailsRef}>
               <div className="card-body">
                 <h2 className="h5">Week Details</h2>
@@ -1010,18 +1010,19 @@ export default function ParentDashboard() {
                 ) : (
                   <>
                     {/* Mobile: collapsible cards per child */}
-                    <div className="d-block d-md-none">
+                    <div className="d-block d-md-none" style={{ contentVisibility: 'auto' as any }}>
                       {children.map((c) => {
                         const w = weeklyByChild[c.id];
                         const open = !!detailsOpen[c.id];
+                        const contentId = `wd-panel-${c.id}`;
                         return (
                           <div key={`wd-card-${c.id}`} className="card mb-2">
-                            <button className="btn text-start w-100 px-3 py-2 d-flex justify-content-between align-items-center" onClick={() => setDetailsOpen((prev) => ({ ...prev, [c.id]: !open }))} aria-expanded={open}>
+                            <button className="btn text-start w-100 px-3 py-2 d-flex justify-content-between align-items-center touch-target" onClick={() => setDetailsOpen((prev) => ({ ...prev, [c.id]: !open }))} aria-expanded={open} aria-controls={contentId}>
                               <span className="fw-semibold text-anywhere">{c.displayName}</span>
                               {w ? <span className="text-muted small">Coins: {w.totalApproved} / {w.totalPlanned}</span> : null}
                             </button>
                             {open && (
-                              <div className="px-3 pb-3">
+                              <div id={contentId} className="px-3 pb-3">
                                 {!w ? (
                                   <div className="text-muted small">No chores this week.</div>
                                 ) : (
@@ -1125,8 +1126,8 @@ export default function ParentDashboard() {
       {/* Sticky mobile actions: Approvals primary controls */}
       <div className="d-md-none" style={{ position: 'fixed', bottom: 0, left: 0, right: 0, zIndex: 1040, background: 'rgba(255,255,255,0.95)', backdropFilter: 'blur(6px)', borderTop: '1px solid var(--border)' }}>
         <div className="container py-2 d-flex gap-2">
-          <button className="btn btn-primary w-100" disabled={payoutBusy || !selectedFamily} onClick={runPayout}>{payoutBusy ? 'Paying…' : 'Run payout'}</button>
-          <button className="btn btn-outline-secondary" style={{ minWidth: 120 }} onClick={() => childrenRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' })}>Add Coins</button>
+          <button className="btn btn-primary w-100 touch-target" disabled={payoutBusy || !selectedFamily} onClick={runPayout}>{payoutBusy ? 'Paying…' : 'Run payout'}</button>
+          <button className="btn btn-outline-secondary touch-target" style={{ minWidth: 120 }} onClick={() => childrenRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' })}>Add Coins</button>
         </div>
       </div>
     </>

--- a/web/src/routes/ParentDashboard.tsx
+++ b/web/src/routes/ParentDashboard.tsx
@@ -4,8 +4,6 @@ import { useNavigate, useLocation } from 'react-router-dom';
 import TopBar from '../components/TopBar';
 
 export default function ParentDashboard() {
-  // TODO(mobile): Wrap ParentDashboard with an AppShell and off-canvas drawer per specs/ParentDashboardMobile.md
-  // TODO(mobile): Ensure global no-x-scroll and long-text wrapping are applied (see spec: overflow-x hidden, text wrapping)
   const nav = useNavigate();
   const loc = useLocation();
   const [token, setToken] = useState<string | null>(null);
@@ -383,7 +381,7 @@ export default function ParentDashboard() {
             <div className="card" ref={childrenRef}>
               <div className="card-body">
                 <h2 className="h5">Children</h2>
-                {/* TODO(mobile): Render stacked cards on small screens; keep table on md+. See specs/ParentDashboardMobile.md */}
+                {/* Children: mobile cards (small) and table (md+) */}
                 {children.length === 0 ? (
                   <div className="text-muted">No children yet.</div>
                 ) : (
@@ -534,7 +532,7 @@ export default function ParentDashboard() {
             <div className="card" ref={choresRef}>
               <div className="card-body">
                 <h2 className="h5">Chores</h2>
-                {/* TODO(mobile): Make new/edit chore forms single-column on small; chips wrap. See spec */}
+                {/* Chores form: single column on small; chips wrap */}
                 <form
                   className="row g-2 mb-3"
                   onSubmit={async (e) => {
@@ -706,7 +704,7 @@ export default function ParentDashboard() {
                     </div>
                   </form>
                 )}
-                {/* TODO(mobile): Render chore rows as cards on small; keep table on md+. Consider compact action menu */}
+                {/* Chores: mobile cards (small) and table (md+) */}
                 {chores.length === 0 ? (
                   <div className="text-muted">No chores yet.</div>
                 ) : (
@@ -826,7 +824,7 @@ export default function ParentDashboard() {
             <div className="card" ref={approvalsRef}>
               <div className="card-body">
                 <h2 className="h5">Approvals</h2>
-                {/* TODO(mobile): Add sticky bottom action bar with Run payout / Add child on small screens */}
+                {/* Approvals: actions above table; sticky action bar provided on mobile */}
                 {approvals.length === 0 ? (
                   <div className="text-muted">No pending approvals.</div>
                 ) : (
@@ -924,7 +922,7 @@ export default function ParentDashboard() {
             <div className="card" ref={weekOverviewRef}>
               <div className="card-body">
                 <h2 className="h5">Week Overview</h2>
-                {/* TODO(mobile): Replace 7-column grid with day pager on small; keep grid on md+ */}
+                {/* Week Overview: day pager on small; 7-col grid on md+ */}
                 {children.length === 0 ? (
                   <div className="text-muted">No children.</div>
                 ) : (

--- a/web/src/routes/ParentDashboard.tsx
+++ b/web/src/routes/ParentDashboard.tsx
@@ -4,6 +4,8 @@ import { useNavigate, useLocation } from 'react-router-dom';
 import TopBar from '../components/TopBar';
 
 export default function ParentDashboard() {
+  // TODO(mobile): Wrap ParentDashboard with an AppShell and off-canvas drawer per specs/ParentDashboardMobile.md
+  // TODO(mobile): Ensure global no-x-scroll and long-text wrapping are applied (see spec: overflow-x hidden, text wrapping)
   const nav = useNavigate();
   const loc = useLocation();
   const [token, setToken] = useState<string | null>(null);
@@ -21,6 +23,8 @@ export default function ParentDashboard() {
   const [payoutBusy, setPayoutBusy] = useState(false);
   const { push } = useToast();
   const [saversByChild, setSaversByChild] = useState<Record<string, any[]>>({});
+  const [weekDayIndex, setWeekDayIndex] = useState(0); // mobile pager for Week Overview
+  const [detailsOpen, setDetailsOpen] = useState<Record<string, boolean>>({}); // mobile accordion for Week Details
   const hashToken = useMemo(() => new URLSearchParams(loc.hash.replace(/^#/, '')).get('token'), [loc.hash]);
 
   useEffect(() => {
@@ -48,6 +52,7 @@ export default function ParentDashboard() {
       .catch(() => setFamilies([]));
   }, [token]);
 
+  // Load core lists when token or selected family changes
   useEffect(() => {
     if (!token || !selectedFamily) return;
     fetch(`/families/${selectedFamily.id}/children`, { headers: { Authorization: `Bearer ${token}` } })
@@ -67,7 +72,11 @@ export default function ParentDashboard() {
       .then((r) => (r.ok ? r.json() : []))
       .then(setApprovals)
       .catch(() => setApprovals([]));
-    // Weekly overview per child
+  }, [token, selectedFamily]);
+
+  // Derive weekly/balances/savers when children list changes
+  useEffect(() => {
+    if (!token || !selectedFamily) return;
     (async () => {
       const map: Record<string, any> = {};
       const bal: Record<string, { available: number; reserved: number }> = {};
@@ -285,7 +294,7 @@ export default function ParentDashboard() {
                   </ul>
                 )}
                 <h3 className="h6">Add co-parent</h3>
-                <form className="d-flex gap-2" onSubmit={handleAddCoParent}>
+                <form className="d-flex gap-2 flex-column flex-sm-row" onSubmit={handleAddCoParent}>
                   <input id="coEmail" type="email" className="form-control" placeholder="parent2@example.com" />
                   <button className="btn btn-outline-primary" type="submit">Add</button>
                 </form>
@@ -320,11 +329,73 @@ export default function ParentDashboard() {
             <div className="card">
               <div className="card-body">
                 <h2 className="h5">Children</h2>
+                {/* TODO(mobile): Render stacked cards on small screens; keep table on md+. See specs/ParentDashboardMobile.md */}
                 {children.length === 0 ? (
                   <div className="text-muted">No children yet.</div>
                 ) : (
-                  <div className="table-responsive">
-                    <table className="table align-middle">
+                  <>
+                    {/* Mobile: stacked cards */}
+                    <section className="d-block d-md-none">
+                      {children.map((c) => (
+                        <div key={`child-card-${c.id}`} className="card mb-2 shadow-sm">
+                          <div className="card-body">
+                            <div className="d-flex justify-content-between align-items-start">
+                              <div>
+                                <div className="fw-semibold text-anywhere">{c.displayName}</div>
+                                <div className="text-muted small">@{c.username}</div>
+                              </div>
+                              <span className="small fw-medium">Total: {(balances[c.id]?.available ?? 0) + (balances[c.id]?.reserved ?? 0)}</span>
+                            </div>
+                            <div className="row row-cols-2 g-2 small mt-2">
+                              <div><span className="text-muted">Available</span> <span>{balances[c.id]?.available ?? 0}</span></div>
+                              <div><span className="text-muted">Allocated</span> <span>{balances[c.id]?.reserved ?? 0}</span></div>
+                            </div>
+                            <form className="row row-cols-2 g-2 mt-2" onSubmit={(e)=>e.preventDefault()}>
+                              <div className="col-12">
+                                <input id={`adj-${c.id}`} type="number" className="form-control form-control-sm" defaultValue={1} />
+                              </div>
+                              <div className="col-6 d-grid">
+                                <button
+                                  className="btn btn-outline-success btn-sm"
+                                  type="button"
+                                  onClick={async () => {
+                                    if (!token) return;
+                                    const amt = parseInt((document.getElementById(`adj-${c.id}`) as HTMLInputElement).value || '0', 10);
+                                    if (!amt) return;
+                                    const r = await fetch(`/bank/${c.id}/adjust`, { method: 'POST', headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` }, body: JSON.stringify({ amount: Math.abs(amt), note: 'credit' }) });
+                                    if (r.ok) push('success', `Credited ${Math.abs(amt)} to ${c.displayName}`); else push('error', 'Credit failed');
+                                    await refreshWeekly();
+                                  }}
+                                >+ Credit</button>
+                              </div>
+                              <div className="col-6 d-grid">
+                                <button
+                                  className="btn btn-outline-danger btn-sm"
+                                  type="button"
+                                  onClick={async () => {
+                                    if (!token) return;
+                                    const amt = parseInt((document.getElementById(`adj-${c.id}`) as HTMLInputElement).value || '0', 10);
+                                    if (!amt) return;
+                                    const r = await fetch(`/bank/${c.id}/adjust`, { method: 'POST', headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` }, body: JSON.stringify({ amount: -Math.abs(amt), note: 'debit' }) });
+                                    if (r.ok) push('success', `Debited ${Math.abs(amt)} from ${c.displayName}`); else push('error', 'Debit failed');
+                                    await refreshWeekly();
+                                  }}
+                                >- Debit</button>
+                              </div>
+                              <div className="col-6 d-grid">
+                                <button className="btn btn-outline-secondary btn-sm" type="button" onClick={() => handleRenameChild(c.id)}>Rename</button>
+                              </div>
+                              <div className="col-6 d-grid">
+                                <button className="btn btn-outline-secondary btn-sm text-danger" type="button" onClick={() => handleDeleteChild(c.id)}>Delete</button>
+                              </div>
+                            </form>
+                          </div>
+                        </div>
+                      ))}
+                    </section>
+                    {/* Desktop: table */}
+                    <div className="d-none d-md-block table-responsive">
+                      <table className="table align-middle">
                       <thead>
                         <tr>
                           <th scope="col">Display name</th>
@@ -345,10 +416,10 @@ export default function ParentDashboard() {
                                 <div className="small text-muted">Available: {balances[c.id]?.available ?? 0} • Allocated: {balances[c.id]?.reserved ?? 0}</div>
                               </div>
                               <form
-                                className="d-flex gap-2 align-items-center mt-2"
+                                className="d-flex gap-2 align-items-stretch align-items-sm-center flex-column flex-sm-row mt-2"
                                 onSubmit={(e) => e.preventDefault()}
                               >
-                                <input id={`adj-${c.id}`} type="number" className="form-control form-control-sm" style={{maxWidth: '7rem'}} defaultValue={1} />
+                                <input id={`adj-${c.id}`} type="number" className="form-control form-control-sm w-100 w-sm-auto" defaultValue={1} />
                                 <button
                                   className="btn btn-sm btn-outline-success"
                                   type="button"
@@ -398,8 +469,9 @@ export default function ParentDashboard() {
                           </tr>
                         ))}
                       </tbody>
-                    </table>
-                  </div>
+                      </table>
+                    </div>
+                  </>
                 )}
               </div>
             </div>
@@ -408,6 +480,7 @@ export default function ParentDashboard() {
             <div className="card">
               <div className="card-body">
                 <h2 className="h5">Chores</h2>
+                {/* TODO(mobile): Make new/edit chore forms single-column on small; chips wrap. See spec */}
                 <form
                   className="row g-2 mb-3"
                   onSubmit={async (e) => {
@@ -579,11 +652,58 @@ export default function ParentDashboard() {
                     </div>
                   </form>
                 )}
+                {/* TODO(mobile): Render chore rows as cards on small; keep table on md+. Consider compact action menu */}
                 {chores.length === 0 ? (
                   <div className="text-muted">No chores yet.</div>
                 ) : (
-                  <div className="table-responsive">
-                    <table className="table align-middle">
+                  <>
+                    {/* Mobile: chore cards */}
+                    <div className="d-block d-md-none">
+                      {chores.map((h) => {
+                        const assigned = children.filter((c) => h.assignedChildIds?.includes(c.id)).map((c) => c.displayName).join(', ') || '-';
+                        return (
+                          <div key={`ch-card-${h.id}`} className="card mb-2">
+                            <div className="card-body">
+                              <div className="d-flex justify-content-between align-items-start">
+                                <div className="fw-semibold text-anywhere">{h.name}</div>
+                                <span className="badge bg-light text-dark">+{h.value}</span>
+                              </div>
+                              <div className="text-muted small mt-1">{h.recurrence === 'weekly' ? `Weekly (${['Sun','Mon','Tue','Wed','Thu','Fri','Sat'][h.dueDay ?? 0]})` : 'Daily'}</div>
+                              <div className="text-muted small mt-1">Assigned: <span className="text-anywhere">{assigned}</span></div>
+                              <div className="d-flex align-items-center gap-2 mt-2">
+                                <div className="form-check form-switch m-0">
+                                  <input
+                                    className="form-check-input"
+                                    type="checkbox"
+                                    id={`active-m-${h.id}`}
+                                    defaultChecked={h.active !== false}
+                                    onChange={async (e) => {
+                                      await fetch(`/chores/${h.id}`, {
+                                        method: 'PATCH',
+                                        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+                                        body: JSON.stringify({ active: e.target.checked })
+                                      });
+                                      await refreshChores();
+                                    }}
+                                  />
+                                  <label className="form-check-label small" htmlFor={`active-m-${h.id}`}>Active</label>
+                                </div>
+                                <button className="btn btn-sm btn-outline-secondary" type="button" onClick={() => setEditingChore(h)}>Edit</button>
+                                <button className="btn btn-sm btn-outline-danger" type="button" onClick={async () => {
+                                  if (!window.confirm('Delete this chore?')) return;
+                                  await fetch(`/chores/${h.id}`, { method: 'DELETE', headers: { Authorization: `Bearer ${token}` } });
+                                  setChores((prev) => prev.filter((x) => x.id !== h.id));
+                                  await refreshWeekly();
+                                }}>Delete</button>
+                              </div>
+                            </div>
+                          </div>
+                        );
+                      })}
+                    </div>
+                    {/* Desktop: table */}
+                    <div className="d-none d-md-block table-responsive">
+                      <table className="table align-middle">
                       <thead>
                         <tr>
                           <th scope="col">Name</th>
@@ -641,8 +761,9 @@ export default function ParentDashboard() {
                           </tr>
                         ))}
                       </tbody>
-                    </table>
-                  </div>
+                      </table>
+                    </div>
+                  </>
                 )}
               </div>
             </div>
@@ -651,6 +772,7 @@ export default function ParentDashboard() {
             <div className="card">
               <div className="card-body">
                 <h2 className="h5">Approvals</h2>
+                {/* TODO(mobile): Add sticky bottom action bar with Run payout / Add child on small screens */}
                 {approvals.length === 0 ? (
                   <div className="text-muted">No pending approvals.</div>
                 ) : (
@@ -748,46 +870,79 @@ export default function ParentDashboard() {
             <div className="card">
               <div className="card-body">
                 <h2 className="h5">Week Overview</h2>
+                {/* TODO(mobile): Replace 7-column grid with day pager on small; keep grid on md+ */}
                 {children.length === 0 ? (
                   <div className="text-muted">No children.</div>
                 ) : (
-                  <div className="table-responsive">
-                    <table className="table align-middle">
-                      <thead>
-                        <tr>
-                          <th scope="col">Child</th>
-                          {['Sun','Mon','Tue','Wed','Thu','Fri','Sat'].map((d) => (
-                            <th key={d} scope="col">{d}</th>
-                          ))}
-                        </tr>
-                      </thead>
-                      <tbody>
+                  <>
+                    {/* Mobile: day pager view */}
+                    <div className="d-block d-md-none">
+                      <div className="d-flex align-items-center justify-content-between border rounded px-3 py-2 mb-2">
+                        <button className="btn btn-link p-0" aria-label="Prev" onClick={() => setWeekDayIndex((d) => (d + 6) % 7)}>‹</button>
+                        <div className="fw-semibold">{['Sun','Mon','Tue','Wed','Thu','Fri','Sat'][weekDayIndex]}</div>
+                        <button className="btn btn-link p-0" aria-label="Next" onClick={() => setWeekDayIndex((d) => (d + 1) % 7)}>›</button>
+                      </div>
+                      <ul className="list-unstyled mb-0">
                         {children.map((c) => {
                           const w = weeklyByChild[c.id];
                           if (!w) return (
-                            <tr key={c.id}>
-                              <td className="fw-semibold">{c.displayName}</td>
-                              {Array.from({ length: 7 }).map((_, i) => <td key={`${c.id}-empty-${i}`}>-</td>)}
-                            </tr>
+                            <li key={`wk-${c.id}`} className="d-flex justify-content-between py-2 border-bottom">
+                              <span className="text-anywhere">{c.displayName}</span>
+                              <span className="text-muted small">-</span>
+                            </li>
                           );
+                          const day = w.days[weekDayIndex];
+                          const planned = day?.items?.length || 0;
+                          const completed = (day?.items || []).filter((it: any) => it.status === 'approved' || it.status === 'pending').length;
+                          const isToday = w.today === weekDayIndex;
                           return (
-                            <tr key={c.id}>
-                              <td className="fw-semibold">{c.displayName}</td>
-                              {w.days.map((day: any, i: number) => {
-                                const planned = day.items.length;
-                                const completed = day.items.filter((it: any) => it.status === 'approved' || it.status === 'pending').length;
-                                return (
-                                  <td key={`${c.id}-${day.date}`} className={w.today === i ? 'table-primary' : ''}>
-                                    <span className="small">{completed}/{planned}</span>
-                                  </td>
-                                );
-                              })}
-                            </tr>
+                            <li key={`wk-${c.id}`} className={`d-flex justify-content-between py-2 border-bottom ${isToday ? 'bg-light' : ''}`}>
+                              <span className="text-anywhere">{c.displayName}</span>
+                              <span className="text-muted small">{completed}/{planned}</span>
+                            </li>
                           );
                         })}
-                      </tbody>
-                    </table>
-                  </div>
+                      </ul>
+                    </div>
+                    {/* Desktop: original 7-day grid */}
+                    <div className="d-none d-md-block table-responsive">
+                      <table className="table align-middle">
+                        <thead>
+                          <tr>
+                            <th scope="col">Child</th>
+                            {['Sun','Mon','Tue','Wed','Thu','Fri','Sat'].map((d) => (
+                              <th key={d} scope="col">{d}</th>
+                            ))}
+                          </tr>
+                        </thead>
+                        <tbody>
+                          {children.map((c) => {
+                            const w = weeklyByChild[c.id];
+                            if (!w) return (
+                              <tr key={c.id}>
+                                <td className="fw-semibold">{c.displayName}</td>
+                                {Array.from({ length: 7 }).map((_, i) => <td key={`${c.id}-empty-${i}`}>-</td>)}
+                              </tr>
+                            );
+                            return (
+                              <tr key={c.id}>
+                                <td className="fw-semibold">{c.displayName}</td>
+                                {w.days.map((day: any, i: number) => {
+                                  const planned = day.items.length;
+                                  const completed = day.items.filter((it: any) => it.status === 'approved' || it.status === 'pending').length;
+                                  return (
+                                    <td key={`${c.id}-${day.date}`} className={w.today === i ? 'table-primary' : ''}>
+                                      <span className="small">{completed}/{planned}</span>
+                                    </td>
+                                  );
+                                })}
+                              </tr>
+                            );
+                          })}
+                        </tbody>
+                      </table>
+                    </div>
+                  </>
                 )}
               </div>
             </div>
@@ -799,62 +954,113 @@ export default function ParentDashboard() {
                 {children.length === 0 ? (
                   <div className="text-muted">No children.</div>
                 ) : (
-                  <div className="row g-3">
-                    {children.map((c) => {
-                      const w = weeklyByChild[c.id];
-                      return (
-                        <div className="col-12 col-lg-6" key={`detail-${c.id}`}>
-                          <div className="border rounded p-3 h-100">
-                            <div className="d-flex justify-content-between align-items-center mb-2">
-                              <h3 className="h6 mb-0">{c.displayName}</h3>
-                              {w ? (
-                                <span className="small text-muted">Coins: {w.totalApproved} / {w.totalPlanned}</span>
-                              ) : null}
-                            </div>
-                            {!w ? (
-                              <div className="text-muted small">No chores this week.</div>
-                            ) : (
-                              <div className="table-responsive">
-                                <table className="table table-sm align-middle mb-0">
-                                  <thead>
-                                    <tr>
-                                      {['Sun','Mon','Tue','Wed','Thu','Fri','Sat'].map((d, i) => (
-                                        <th key={`${c.id}-head-${d}`} className={w.today === i ? 'table-primary' : ''}>{d}</th>
-                                      ))}
-                                    </tr>
-                                  </thead>
-                                  <tbody>
-                                    <tr>
-                                      {w.days.map((day: any, i: number) => (
-                                        <td key={`${c.id}-day-${day.date}`} className={w.today === i ? 'table-primary' : ''}>
-                                          {day.items.length === 0 ? (
-                                            <span className="text-muted small">-</span>
-                                          ) : (
-                                            <ul className="list-unstyled mb-0 small">
-                                              {day.items.map((it: any) => (
-                                                <li key={`${c.id}-${day.date}-${it.id}`}>
-                                                  {it.name} <span className="text-muted">(+{it.value})</span>{' '}
-                                                  {it.status === 'approved' && <span className="badge bg-success">Completed</span>}
-                                                  {it.status === 'pending' && <span className="badge bg-warning text-dark">Pending</span>}
-                                                  {it.status === 'missed' && <span className="badge bg-danger">Missed</span>}
-                                                  {it.status === 'due' && <span className="badge bg-info text-dark">Due</span>}
-                                                  {it.status === 'planned' && <span className="badge bg-light text-dark">Planned</span>}
-                                                </li>
-                                              ))}
-                                            </ul>
-                                          )}
-                                        </td>
-                                      ))}
-                                    </tr>
-                                  </tbody>
-                                </table>
+                  <>
+                    {/* Mobile: collapsible cards per child */}
+                    <div className="d-block d-md-none">
+                      {children.map((c) => {
+                        const w = weeklyByChild[c.id];
+                        const open = !!detailsOpen[c.id];
+                        return (
+                          <div key={`wd-card-${c.id}`} className="card mb-2">
+                            <button className="btn text-start w-100 px-3 py-2 d-flex justify-content-between align-items-center" onClick={() => setDetailsOpen((prev) => ({ ...prev, [c.id]: !open }))} aria-expanded={open}>
+                              <span className="fw-semibold text-anywhere">{c.displayName}</span>
+                              {w ? <span className="text-muted small">Coins: {w.totalApproved} / {w.totalPlanned}</span> : null}
+                            </button>
+                            {open && (
+                              <div className="px-3 pb-3">
+                                {!w ? (
+                                  <div className="text-muted small">No chores this week.</div>
+                                ) : (
+                                  <div className="row row-cols-2 g-2">
+                                    {w.days.map((day: any, i: number) => (
+                                      <div key={`${c.id}-day-m-${day.date}`} className={`border rounded p-2 ${w.today === i ? 'bg-light' : ''}`}>
+                                        <div className="text-muted small">{['Sun','Mon','Tue','Wed','Thu','Fri','Sat'][i]}</div>
+                                        {(day.items || []).length === 0 ? (
+                                          <div className="text-muted small">-</div>
+                                        ) : (
+                                          <ul className="list-unstyled mb-0 small">
+                                            {day.items.map((it: any) => (
+                                              <li key={`${c.id}-${day.date}-${it.id}`} className="text-anywhere">
+                                                {it.name} <span className="text-muted">(+{it.value})</span>
+                                                {it.status === 'approved' && <span className="ms-2 badge bg-success">Completed</span>}
+                                                {it.status === 'pending' && <span className="ms-2 badge bg-warning text-dark">Pending</span>}
+                                                {it.status === 'missed' && <span className="ms-2 badge bg-danger">Missed</span>}
+                                                {it.status === 'due' && <span className="ms-2 badge bg-info text-dark">Due</span>}
+                                                {it.status === 'planned' && <span className="ms-2 badge bg-light text-dark">Planned</span>}
+                                              </li>
+                                            ))}
+                                          </ul>
+                                        )}
+                                      </div>
+                                    ))}
+                                  </div>
+                                )}
                               </div>
                             )}
                           </div>
-                        </div>
-                      );
-                    })}
-                  </div>
+                        );
+                      })}
+                    </div>
+                    {/* Desktop: existing table detail view */}
+                    <div className="d-none d-md-block">
+                      <div className="row g-3">
+                        {children.map((c) => {
+                          const w = weeklyByChild[c.id];
+                          return (
+                            <div className="col-12 col-lg-6" key={`detail-${c.id}`}>
+                              <div className="border rounded p-3 h-100">
+                                <div className="d-flex justify-content-between align-items-center mb-2">
+                                  <h3 className="h6 mb-0">{c.displayName}</h3>
+                                  {w ? (
+                                    <span className="small text-muted">Coins: {w.totalApproved} / {w.totalPlanned}</span>
+                                  ) : null}
+                                </div>
+                                {!w ? (
+                                  <div className="text-muted small">No chores this week.</div>
+                                ) : (
+                                  <div className="table-responsive">
+                                    <table className="table table-sm align-middle mb-0">
+                                      <thead>
+                                        <tr>
+                                          {['Sun','Mon','Tue','Wed','Thu','Fri','Sat'].map((d, i) => (
+                                            <th key={`${c.id}-head-${d}`} className={w.today === i ? 'table-primary' : ''}>{d}</th>
+                                          ))}
+                                        </tr>
+                                      </thead>
+                                      <tbody>
+                                        <tr>
+                                          {w.days.map((day: any, i: number) => (
+                                            <td key={`${c.id}-day-${day.date}`} className={w.today === i ? 'table-primary' : ''}>
+                                              {day.items.length === 0 ? (
+                                                <span className="text-muted small">-</span>
+                                              ) : (
+                                                <ul className="list-unstyled mb-0 small">
+                                                  {day.items.map((it: any) => (
+                                                    <li key={`${c.id}-${day.date}-${it.id}`}>
+                                                      {it.name} <span className="text-muted">(+{it.value})</span>{' '}
+                                                      {it.status === 'approved' && <span className="badge bg-success">Completed</span>}
+                                                      {it.status === 'pending' && <span className="badge bg-warning text-dark">Pending</span>}
+                                                      {it.status === 'missed' && <span className="badge bg-danger">Missed</span>}
+                                                      {it.status === 'due' && <span className="badge bg-info text-dark">Due</span>}
+                                                      {it.status === 'planned' && <span className="badge bg-light text-dark">Planned</span>}
+                                                    </li>
+                                                  ))}
+                                                </ul>
+                                              )}
+                                            </td>
+                                          ))}
+                                        </tr>
+                                      </tbody>
+                                    </table>
+                                  </div>
+                                )}
+                              </div>
+                            </div>
+                          );
+                        })}
+                      </div>
+                    </div>
+                  </>
                 )}
               </div>
             </div>

--- a/web/src/styles/mobile.css
+++ b/web/src/styles/mobile.css
@@ -45,3 +45,7 @@ html.is-mobile .card {
     padding-right: max(env(safe-area-inset-right), 0px);
   }
 }
+
+.mobile-bottom {
+  padding-bottom: 75px;
+}

--- a/web/src/styles/tokens.css
+++ b/web/src/styles/tokens.css
@@ -40,6 +40,11 @@ body {
   font-family: 'Inter', system-ui, -apple-system, Segoe UI, Roboto, 'Helvetica Neue', Arial, 'Noto Sans', 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
 }
 
+/* Mobile guardrails: prevent accidental horizontal scrolling and force long text to wrap */
+html, body { overflow-x: hidden; }
+.text-anywhere { overflow-wrap: anywhere; word-break: break-word; }
+.wrap-long { white-space: normal !important; overflow-wrap: anywhere; }
+
 /* Cute background variant with tiled cherries (toggle via body.cute-bg-on) */
 /* Pattern layer behind everything via mask */
 body.cute-bg-on::before {

--- a/web/src/styles/tokens.css
+++ b/web/src/styles/tokens.css
@@ -44,6 +44,8 @@ body {
 html, body { overflow-x: hidden; }
 .text-anywhere { overflow-wrap: anywhere; word-break: break-word; }
 .wrap-long { white-space: normal !important; overflow-wrap: anywhere; }
+/* Ensure comfortable tap targets on mobile */
+.touch-target { min-height: 44px; min-width: 44px; }
 
 /* Cute background variant with tiled cherries (toggle via body.cute-bg-on) */
 /* Pattern layer behind everything via mask */


### PR DESCRIPTION
- **Parent dashboard mobile: Week Overview pager, Week Details accordion, Children & Chores mobile cards; global no-x-scroll; goal image upload for savers; clickable avatar/name to profile; add ParentDashboardMobile spec and link TODOs.**
- **Parent dashboard mobile: add sticky bottom action bar (Run payout, Add child), extract runPayout, and smooth-scroll to Add child form on mobile.**
- **Parent dashboard AppShell: add hamburger-triggered off-canvas drawer with section links and smooth scrolling; add section refs; pad bottom for sticky bar on mobile.**
- **Parent dashboard mobile: increase bottom padding for Week Details reachability; change sticky action button to 'Add Coins' and scroll to Children section.**
- **Mobile polish: add touch-target utility, aria-controls for Week Details disclosure, content-visibility:auto for long mobile lists, and larger tap targets for sticky actions and drawer links.**
- **Clean up mobile TODOs in ParentDashboard; clarify section comments; keep behavior unchanged.**
