### PR TITLE
Add Alexa skill support and long-lived API tokens

### DIFF
--- a/alexa/README.md
+++ b/alexa/README.md
@@ -1,0 +1,31 @@
+Cherry Chores Alexa Skill
+
+Overview
+- Provides voice interactions for kids and parents:
+  - Kids: “What chores do I have today?”
+  - Kids: “I finished <chore>.”
+  - Kids: “How much money is in my bank?”
+  - Parents: “What chores are left to finish?” (responds for all children)
+
+Structure
+- `src/index.js`: AWS Lambda handler for Alexa skill requests. Calls the Cherry Chores API with a long‑lived API token.
+- `models/en-US.json`: Example interaction model with intents and sample utterances.
+
+Configuration
+- API host: set `API_BASE_URL` (e.g. https://api.yourdomain.com)
+- API token: set `API_TOKEN` to a parent long‑lived token created in Parent Dashboard → API Tokens.
+
+Local Dev
+- The handler expects standard Alexa request JSONs. You can use the Alexa Developer Console or ask-cli to wire this Lambda and interaction model.
+- Node.js 18+ recommended (uses global fetch).
+
+Intents
+- GetChoresIntent (ChildName optional): lists today’s chores for the child; if no child provided, attempts to infer the first child.
+- CompleteChoreIntent (ChildName, ChoreName): marks the chore complete for today.
+- GetBalanceIntent (ChildName optional): reads the available balance for the child.
+- GetRemainingChoresIntent: for parents; summarizes remaining chores for all children today.
+
+Notes
+- Name matching is case-insensitive and fuzzy by prefix where possible.
+- This is a minimal, dependency-free handler; you can migrate to ask-sdk later if desired.
+

--- a/alexa/models/en-US.json
+++ b/alexa/models/en-US.json
@@ -1,0 +1,65 @@
+{
+  "interactionModel": {
+    "languageModel": {
+      "invocationName": "cherry chores",
+      "intents": [
+        {
+          "name": "AMAZON.CancelIntent",
+          "samples": []
+        },
+        {
+          "name": "AMAZON.HelpIntent",
+          "samples": []
+        },
+        {
+          "name": "AMAZON.StopIntent",
+          "samples": []
+        },
+        {
+          "name": "GetChoresIntent",
+          "slots": [
+            { "name": "ChildName", "type": "AMAZON.FirstName" }
+          ],
+          "samples": [
+            "what chores do I have today",
+            "what chores does {ChildName} have today",
+            "what are {ChildName}'s chores",
+            "list chores for {ChildName}"
+          ]
+        },
+        {
+          "name": "CompleteChoreIntent",
+          "slots": [
+            { "name": "ChildName", "type": "AMAZON.FirstName" },
+            { "name": "ChoreName", "type": "AMAZON.SearchQuery" }
+          ],
+          "samples": [
+            "I finished {ChoreName}",
+            "mark {ChoreName} done",
+            "{ChildName} finished {ChoreName}"
+          ]
+        },
+        {
+          "name": "GetBalanceIntent",
+          "slots": [
+            { "name": "ChildName", "type": "AMAZON.FirstName" }
+          ],
+          "samples": [
+            "how much money is in my bank",
+            "what's {ChildName}'s balance",
+            "how many coins does {ChildName} have"
+          ]
+        },
+        {
+          "name": "GetRemainingChoresIntent",
+          "samples": [
+            "what chores are left",
+            "what chores are left to finish"
+          ]
+        }
+      ],
+      "types": []
+    }
+  }
+}
+

--- a/alexa/src/index.js
+++ b/alexa/src/index.js
@@ -1,0 +1,140 @@
+// Minimal Alexa Lambda handler for Cherry Chores
+// Env: API_BASE_URL, API_TOKEN (parent long-lived token)
+
+const API = process.env.API_BASE_URL?.replace(/\/$/, '') || 'http://localhost:3000';
+const TOKEN = process.env.API_TOKEN;
+
+async function api(path, opts = {}) {
+  if (!TOKEN) throw new Error('Missing API_TOKEN');
+  const res = await fetch(`${API}${path}`, {
+    ...opts,
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Api-Key': TOKEN,
+      ...(opts.headers || {})
+    }
+  });
+  if (!res.ok) {
+    let msg = `HTTP ${res.status}`;
+    try { const data = await res.json(); if (data?.error) msg += `: ${data.error}`; } catch {}
+    throw new Error(msg);
+  }
+  try { return await res.json(); } catch { return null; }
+}
+
+async function getFamilies() {
+  return api('/families');
+}
+async function getChildren(familyId) {
+  return api(`/families/${familyId}/children`);
+}
+async function getTodayChores(childId) {
+  return api(`/children/${childId}/chores?scope=today`);
+}
+async function completeChore(choreId, childId) {
+  return api(`/chores/${encodeURIComponent(choreId)}/complete`, { method: 'POST', body: JSON.stringify({ childId }) });
+}
+async function getBalance(childId) {
+  return api(`/bank/${childId}`);
+}
+
+function findChildByName(children, name) {
+  if (!name) return children[0];
+  const lower = name.toLowerCase();
+  return children.find(c => c.displayName?.toLowerCase() === lower)
+      || children.find(c => c.displayName?.toLowerCase().startsWith(lower))
+      || children.find(c => c.username?.toLowerCase() === lower)
+      || null;
+}
+
+function findChoreByName(list, name) {
+  if (!name) return null;
+  const lower = name.toLowerCase();
+  return list.find(c => c.name?.toLowerCase() === lower)
+      || list.find(c => c.name?.toLowerCase().includes(lower))
+      || null;
+}
+
+function speak(text) {
+  return {
+    version: '1.0',
+    response: {
+      outputSpeech: { type: 'PlainText', text },
+      shouldEndSession: true
+    }
+  };
+}
+
+exports.handler = async (event) => {
+  try {
+    const type = event.request?.type;
+    if (type === 'LaunchRequest') {
+      return speak('Welcome to Cherry Chores. Ask about chores or balances.');
+    }
+    if (type === 'IntentRequest') {
+      const intent = event.request.intent?.name;
+      const slots = event.request.intent?.slots || {};
+      const childName = slots.ChildName?.value;
+      const choreName = slots.ChoreName?.value;
+
+      const families = await getFamilies();
+      const family = families?.[0];
+      if (!family) return speak('I could not find a family linked to this token.');
+      const children = await getChildren(family.id);
+      if (!Array.isArray(children) || children.length === 0) return speak('There are no children in your family yet.');
+
+      if (intent === 'GetChoresIntent') {
+        const child = findChildByName(children, childName);
+        if (!child) return speak(`I couldn't find ${childName}.`);
+        const chores = await getTodayChores(child.id);
+        if (!chores || chores.length === 0) return speak(`${child.displayName} has no chores today.`);
+        const remaining = chores.filter(c => !c.status || c.status === 'due' || c.status === 'planned');
+        if (remaining.length === 0) return speak(`${child.displayName} finished all chores for today. Great job!`);
+        const names = remaining.map(c => c.name).slice(0, 5).join(', ');
+        return speak(`${child.displayName} has ${remaining.length} chore${remaining.length>1?'s':''} today: ${names}.`);
+      }
+
+      if (intent === 'CompleteChoreIntent') {
+        const child = findChildByName(children, childName);
+        if (!child) return speak(`I couldn't find ${childName}.`);
+        const chores = await getTodayChores(child.id);
+        const match = findChoreByName(chores || [], choreName);
+        if (!match) return speak(`I couldn't find the chore ${choreName} for ${child.displayName} today.`);
+        await completeChore(match.id, child.id);
+        return speak(`Marked ${match.name} as completed for ${child.displayName}.`);
+      }
+
+      if (intent === 'GetBalanceIntent') {
+        const child = findChildByName(children, childName);
+        if (!child) return speak(`I couldn't find ${childName}.`);
+        const bal = await getBalance(child.id);
+        const amt = Math.round((bal?.balance?.available || 0) * 100) / 100;
+        return speak(`${child.displayName} has ${amt} coins available.`);
+      }
+
+      if (intent === 'GetRemainingChoresIntent') {
+        // Summarize remaining chores for all children
+        const reports = [];
+        for (const ch of children) {
+          const chores = await getTodayChores(ch.id);
+          const remaining = (chores || []).filter(c => !c.status || c.status === 'due' || c.status === 'planned');
+          if (remaining.length > 0) {
+            reports.push(`${ch.displayName}: ${remaining.length}`);
+          }
+        }
+        if (reports.length === 0) return speak('All chores are complete for today.');
+        return speak(`Remaining chores — ${reports.join('; ')}.`);
+      }
+
+      return speak('Sorry, I did not understand that request.');
+    }
+    if (type === 'SessionEndedRequest') {
+      return speak('Goodbye.');
+    }
+    return speak('Hello from Cherry Chores.');
+  } catch (err) {
+    console.error(err);
+    return speak('Something went wrong talking to Cherry Chores.');
+  }
+};
+

--- a/api/src/repos.tokens.pg.ts
+++ b/api/src/repos.tokens.pg.ts
@@ -1,0 +1,65 @@
+import { Pool } from 'pg';
+import crypto from 'crypto';
+import { TokensRepository } from './repositories';
+
+export class PgTokensRepo implements TokensRepository {
+  constructor(private pool: Pool) {}
+
+  async init() {
+    await this.pool.query(`
+      CREATE TABLE IF NOT EXISTS api_tokens (
+        id TEXT PRIMARY KEY,
+        parent_id TEXT NOT NULL REFERENCES parents(id) ON DELETE CASCADE,
+        label TEXT,
+        token_hash TEXT NOT NULL UNIQUE,
+        created_at TIMESTAMP NOT NULL,
+        last_used_at TIMESTAMP,
+        expires_at TIMESTAMP
+      );
+      CREATE INDEX IF NOT EXISTS idx_api_tokens_parent ON api_tokens(parent_id);
+      CREATE INDEX IF NOT EXISTS idx_api_tokens_token_hash ON api_tokens(token_hash);
+    `);
+  }
+
+  async createToken(parentId: string, label?: string, expiresAt?: string | null) {
+    const id = `tok_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+    const raw = crypto.randomBytes(24).toString('hex');
+    const tokenHash = crypto.createHash('sha256').update(raw).digest('hex');
+    const createdAt = new Date().toISOString();
+    await this.pool.query(
+      `INSERT INTO api_tokens(id, parent_id, label, token_hash, created_at, expires_at)
+       VALUES ($1,$2,$3,$4,$5,$6)`,
+      [id, parentId, label ?? null, tokenHash, createdAt, expiresAt ?? null]
+    );
+    return { id, token: raw, label, createdAt, expiresAt: expiresAt ?? null };
+  }
+
+  async listTokens(parentId: string) {
+    const r = await this.pool.query(
+      'SELECT id, label, created_at, last_used_at, expires_at FROM api_tokens WHERE parent_id=$1 ORDER BY created_at DESC',
+      [parentId]
+    );
+    return r.rows.map((row) => ({
+      id: row.id as string,
+      label: (row.label ?? undefined) as string | undefined,
+      createdAt: new Date(row.created_at).toISOString(),
+      lastUsedAt: row.last_used_at ? new Date(row.last_used_at).toISOString() : undefined,
+      expiresAt: row.expires_at ? new Date(row.expires_at).toISOString() : null
+    }));
+  }
+
+  async revokeToken(parentId: string, id: string) {
+    await this.pool.query('DELETE FROM api_tokens WHERE id=$1 AND parent_id=$2', [id, parentId]);
+  }
+
+  async verify(rawToken: string) {
+    const tokenHash = crypto.createHash('sha256').update(rawToken).digest('hex');
+    const r = await this.pool.query('SELECT id, parent_id, expires_at FROM api_tokens WHERE token_hash=$1', [tokenHash]);
+    if (!r.rowCount) return null;
+    const row = r.rows[0];
+    if (row.expires_at && new Date(row.expires_at).getTime() < Date.now()) return null;
+    await this.pool.query('UPDATE api_tokens SET last_used_at=$1 WHERE id=$2', [new Date().toISOString(), row.id]);
+    return { parentId: row.parent_id as string, tokenId: row.id as string };
+  }
+}
+

--- a/api/src/routes/tokens.ts
+++ b/api/src/routes/tokens.ts
@@ -1,0 +1,34 @@
+import { Request, Router } from 'express';
+import { AuthedRequest, requireRole } from '../middleware/auth';
+import { TokensRepository, UsersRepository } from '../repositories';
+
+export function tokenRoutes(opts: { tokens: TokensRepository; users: UsersRepository }) {
+  const router = Router();
+  const { tokens } = opts;
+
+  // List tokens for current parent
+  router.get('/tokens', requireRole('parent'), async (req: Request, res) => {
+    const parentId = (req as AuthedRequest).user!.id;
+    const list = await tokens.listTokens(parentId);
+    res.json(list);
+  });
+
+  // Create token for current parent
+  router.post('/tokens', requireRole('parent'), async (req: Request, res) => {
+    const parentId = (req as AuthedRequest).user!.id;
+    const { label, expiresAt } = req.body || {};
+    const rec = await tokens.createToken(parentId, label, typeof expiresAt === 'string' ? expiresAt : undefined);
+    // Return raw token only at creation time
+    res.status(201).json(rec);
+  });
+
+  // Revoke token by id (must belong to current parent)
+  router.delete('/tokens/:id', requireRole('parent'), async (req: Request, res) => {
+    const parentId = (req as AuthedRequest).user!.id;
+    await tokens.revokeToken(parentId, req.params.id);
+    res.status(204).send();
+  });
+
+  return router;
+}
+


### PR DESCRIPTION
This PR adds Alexa integration and long-lived API tokens.

Highlights
- Alexa skill scaffold in `alexa/`: Lambda handler and en-US model supporting:
- Kids: ask chores for today, mark a chore complete, ask balance
- Parents: ask remaining chores across kids
- API tokens:
- New endpoints: `GET /tokens`, `POST /tokens`, `DELETE /tokens/:id`
- In-memory + Postgres repo (`api_tokens` table, SHA-256 hashes)
- Auth middleware accepts `X-Api-Key` for parent access
- Parent Dashboard UI:
- Manage API tokens (create, view-once token value, revoke)
 
Notes
- API and web build cleanly.
- Alexa handler needs `API_BASE_URL` and a parent `API_TOKEN` created in the dashboard.