### PR TITLE
Phase 10: Bulk Approvals (MVP complete)

### DIFF
--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -31,6 +31,7 @@ import { InMemoryBonusRepo, InMemoryActivityRepo } from './repositories';
 import { PgBonusRepo } from './repos.bonus.pg';
 import { PgActivityRepo } from './repos.activity.pg';
 import { activityRoutes } from './routes/activity';
+import { approvalsRoutes } from './routes/approvals';
 
 export function createApp(deps?: { useDb?: boolean }) {
   const app = express();
@@ -100,6 +101,7 @@ export function createApp(deps?: { useDb?: boolean }) {
     app.use(saversRoutes({ savers: saversRepo, users: repos, families: repos, bank: bankRepo }));
     app.use('/api', bonusRoutes({ bonus: bonusRepo, users: repos, families: repos, bank: bankRepo, savers: saversRepo }));
     app.use('/api', activityRoutes({ activity: activityRepo, families: repos }));
+    app.use('/api', approvalsRoutes({ chores: choresRepo, bonus: bonusRepo, bank: bankRepo, users: repos, families: repos, savers: saversRepo, activity: activityRepo }));
     const uploadsRepo = new (require('./repos.uploads.pg').PgUploadsRepo)(pool);
     uploadsRepo.init().catch(() => {});
     app.use(childrenRoutes({ users: repos, families: repos, uploads: uploadsRepo }));
@@ -112,6 +114,7 @@ export function createApp(deps?: { useDb?: boolean }) {
     app.use(saversRoutes({ savers: repos as any, users: repos, families: repos, bank: repos as any }));
     app.use('/api', bonusRoutes({ bonus: bonusRepo, users: repos, families: repos, bank: repos as any, savers: repos as any }));
     app.use('/api', activityRoutes({ activity: activityRepo, families: repos }));
+    app.use('/api', approvalsRoutes({ chores: repos as any, bonus: bonusRepo, bank: repos as any, users: repos, families: repos, savers: repos as any, activity: activityRepo }));
     app.use(childrenRoutes({ users: repos, families: repos }));
   }
 

--- a/api/src/routes/approvals.ts
+++ b/api/src/routes/approvals.ts
@@ -1,0 +1,196 @@
+import { Request, Router } from 'express';
+import { AuthedRequest, requireRole } from '../middleware/auth';
+import {
+  ActivityRepository,
+  BankRepository,
+  BonusRepository,
+  ChoresRepository,
+  FamiliesRepository,
+  SaversRepository,
+  UsersRepository,
+} from '../repositories';
+import { LedgerEntry } from '../bank.types';
+import { applyAllocation } from '../alloc';
+import { emitActivity } from '../activity';
+
+export function approvalsRoutes(opts: {
+  chores: ChoresRepository;
+  bonus: BonusRepository;
+  bank: BankRepository;
+  users: UsersRepository;
+  families: FamiliesRepository;
+  savers?: SaversRepository;
+  activity?: ActivityRepository;
+}) {
+  const router = Router();
+  const { chores, bonus, bank, users, families, savers, activity } = opts;
+
+  /**
+   * POST /api/approvals/bulk-approve
+   *
+   * Body: { completionIds?: string[], claimIds?: string[] }
+   * At least one array must be non-empty.
+   *
+   * Returns 200 { succeeded: string[], failed: Array<{ id: string, error: string }> }
+   */
+  router.post('/approvals/bulk-approve', requireRole('parent'), async (req: Request, res) => {
+    const actor = (req as AuthedRequest).user!;
+    const { completionIds, claimIds } = req.body || {};
+
+    const cids: string[] = Array.isArray(completionIds) ? completionIds : [];
+    const kids: string[] = Array.isArray(claimIds) ? claimIds : [];
+
+    if (cids.length === 0 && kids.length === 0) {
+      return res.status(400).json({ error: 'no ids provided' });
+    }
+
+    const succeeded: string[] = [];
+    const failed: Array<{ id: string; error: string }> = [];
+
+    // Process completion IDs
+    for (const id of cids) {
+      try {
+        // Find the completion — we need to search across families the parent belongs to.
+        // We get the completion by scanning pending completions per family.
+        // First try to find which family this completion belongs to by fetching the parent's families.
+        const parent = await users.getParentById(actor.id);
+        if (!parent) {
+          failed.push({ id, error: 'parent not found' });
+          continue;
+        }
+
+        // Find the completion across all parent families
+        let pending = null;
+        let completionFamilyId: string | null = null;
+        for (const fid of parent.families) {
+          const fam = await families.getFamilyById(fid);
+          if (!fam || !fam.parentIds.includes(actor.id)) continue;
+          const pendingList = await chores.listPendingCompletionsByFamily(fid);
+          const found = pendingList.find((x) => x.id === id);
+          if (found) {
+            pending = found;
+            completionFamilyId = fid;
+            break;
+          }
+        }
+
+        if (!pending || !completionFamilyId) {
+          failed.push({ id, error: 'not found' });
+          continue;
+        }
+
+        // Verify the chore's family belongs to this parent
+        const choreItem = await chores.getChoreById(pending.choreId);
+        if (!choreItem) {
+          failed.push({ id, error: 'chore not found' });
+          continue;
+        }
+        const fam = await families.getFamilyById(choreItem.familyId);
+        if (!fam || !fam.parentIds.includes(actor.id)) {
+          failed.push({ id, error: 'forbidden' });
+          continue;
+        }
+
+        // Approve: delete pending and create approved
+        await chores.deleteCompletion(pending.id);
+        await chores.createCompletion({
+          ...pending,
+          id: `comp_${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
+          status: 'approved',
+        });
+
+        // Emit activity
+        await emitActivity(activity, {
+          familyId: choreItem.familyId,
+          childId: pending.childId,
+          eventType: 'chore_approved',
+          actorId: actor.id,
+          actorRole: 'parent',
+          refId: pending.choreId,
+          amount: choreItem.value,
+        });
+
+        succeeded.push(id);
+      } catch (err: any) {
+        failed.push({ id, error: err?.message || 'unexpected error' });
+      }
+    }
+
+    // Process claim IDs
+    for (const id of kids) {
+      try {
+        const claim = await bonus.getClaimById(id);
+        if (!claim) {
+          failed.push({ id, error: 'claim not found' });
+          continue;
+        }
+        if (claim.status !== 'pending') {
+          failed.push({ id, error: 'claim is not pending' });
+          continue;
+        }
+
+        const b = await bonus.getBonusById(claim.bonusId);
+        if (!b) {
+          failed.push({ id, error: 'bonus not found' });
+          continue;
+        }
+
+        const fam = await families.getFamilyById(b.familyId);
+        if (!fam || !fam.parentIds.includes(actor.id)) {
+          failed.push({ id, error: 'forbidden' });
+          continue;
+        }
+
+        // Verify the child belongs to this family
+        const child = await users.getChildById(claim.childId);
+        if (!child || child.familyId !== b.familyId) {
+          failed.push({ id, error: 'child not in family' });
+          continue;
+        }
+
+        // Create ledger entry
+        const entry: LedgerEntry = {
+          id: `bonus_entry_${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
+          childId: claim.childId,
+          amount: b.value,
+          type: 'bonus',
+          note: `Bonus: ${b.name}`,
+          meta: { bonusId: b.id, claimId: claim.id },
+          actor: { role: 'parent', id: actor.id },
+          createdAt: new Date().toISOString(),
+        };
+        await bank.addLedgerEntry(entry);
+
+        // Apply auto-allocation if savers configured
+        if (savers) await applyAllocation(bank, savers, claim.childId, b.value);
+
+        // Update claim status
+        await bonus.updateClaim({
+          ...claim,
+          status: 'approved',
+          resolvedAt: new Date().toISOString(),
+          resolvedBy: actor.id,
+        });
+
+        // Emit activity
+        await emitActivity(activity, {
+          familyId: b.familyId,
+          childId: claim.childId,
+          eventType: 'bonus_approved',
+          actorId: actor.id,
+          actorRole: 'parent',
+          refId: b.id,
+          amount: b.value,
+        });
+
+        succeeded.push(id);
+      } catch (err: any) {
+        failed.push({ id, error: err?.message || 'unexpected error' });
+      }
+    }
+
+    return res.status(200).json({ succeeded, failed });
+  });
+
+  return router;
+}

--- a/api/tests/phase10.bulk-approvals.test.ts
+++ b/api/tests/phase10.bulk-approvals.test.ts
@@ -1,0 +1,245 @@
+import request from 'supertest';
+import { createApp } from '../src/app';
+
+describe('Phase 10: Bulk Approvals', () => {
+  const app = createApp();
+  let parentToken = '';
+  let familyId = '';
+  let childId = '';
+  let choreId = '';
+
+  // Setup: create parent, family, child, and a chore that requires approval
+  beforeAll(async () => {
+    const p = await request(app)
+      .post('/auth/google/callback')
+      .send({ idToken: 'bulkparent@example.com', familyName: 'BulkFam', timezone: 'UTC' })
+      .expect(200);
+    parentToken = p.body.token;
+    familyId = p.body.familyId;
+
+    const c = await request(app)
+      .post('/children')
+      .set('Authorization', `Bearer ${parentToken}`)
+      .send({ familyId, username: 'bulkkid', password: 'pw', displayName: 'Bulk Kid' })
+      .expect(201);
+    childId = c.body.id;
+
+    const ch = await request(app)
+      .post('/chores')
+      .set('Authorization', `Bearer ${parentToken}`)
+      .send({ familyId, name: 'Bulk Chore', value: 5, recurrence: 'daily', requiresApproval: true, assignedChildIds: [childId] })
+      .expect(201);
+    choreId = ch.body.id;
+  });
+
+  it('bulk approve two chores at once — both succeed, two activity entries created', async () => {
+    // Create two completions
+    const comp1 = await request(app)
+      .post(`/chores/${choreId}/complete`)
+      .send({ childId, date: '2026-01-01' })
+      .expect(200);
+
+    // Need a second chore to create a second completion with different date
+    const ch2 = await request(app)
+      .post('/chores')
+      .set('Authorization', `Bearer ${parentToken}`)
+      .send({ familyId, name: 'Bulk Chore 2', value: 3, recurrence: 'daily', requiresApproval: true, assignedChildIds: [childId] })
+      .expect(201);
+
+    const comp2 = await request(app)
+      .post(`/chores/${ch2.body.id}/complete`)
+      .send({ childId, date: '2026-01-02' })
+      .expect(200);
+
+    const res = await request(app)
+      .post('/api/approvals/bulk-approve')
+      .set('Authorization', `Bearer ${parentToken}`)
+      .send({ completionIds: [comp1.body.id, comp2.body.id] })
+      .expect(200);
+
+    expect(res.body.succeeded).toHaveLength(2);
+    expect(res.body.succeeded).toContain(comp1.body.id);
+    expect(res.body.succeeded).toContain(comp2.body.id);
+    expect(res.body.failed).toHaveLength(0);
+
+    // Verify activity was created (2 chore_approved entries in feed)
+    const actRes = await request(app)
+      .get(`/api/families/${familyId}/activity?limit=10`)
+      .set('Authorization', `Bearer ${parentToken}`)
+      .expect(200);
+    const approvedEntries = actRes.body.entries.filter((e: any) => e.eventType === 'chore_approved');
+    expect(approvedEntries.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('bulk approve mix of chore completion + bonus claim — both succeed', async () => {
+    // Create a new chore completion
+    const ch3 = await request(app)
+      .post('/chores')
+      .set('Authorization', `Bearer ${parentToken}`)
+      .send({ familyId, name: 'Mix Chore', value: 4, recurrence: 'daily', requiresApproval: true, assignedChildIds: [childId] })
+      .expect(201);
+
+    const comp3 = await request(app)
+      .post(`/chores/${ch3.body.id}/complete`)
+      .send({ childId, date: '2026-01-03' })
+      .expect(200);
+
+    // Create a bonus and claim
+    const bon = await request(app)
+      .post(`/api/families/${familyId}/bonuses`)
+      .set('Authorization', `Bearer ${parentToken}`)
+      .send({ name: 'Mix Bonus', value: 10, claimType: 'one-time', childIds: [childId] })
+      .expect(201);
+
+    // Log in as the child to claim the bonus
+    const childLoginRes = await request(app)
+      .post('/auth/child/login')
+      .send({ username: 'bulkkid', password: 'pw' })
+      .expect(200);
+    const childToken = childLoginRes.body.token;
+
+    const claimRes = await request(app)
+      .post(`/api/bonuses/${bon.body.id}/claim`)
+      .set('Authorization', `Bearer ${childToken}`)
+      .send({})
+      .expect(201);
+
+    const res = await request(app)
+      .post('/api/approvals/bulk-approve')
+      .set('Authorization', `Bearer ${parentToken}`)
+      .send({ completionIds: [comp3.body.id], claimIds: [claimRes.body.id] })
+      .expect(200);
+
+    expect(res.body.succeeded).toHaveLength(2);
+    expect(res.body.succeeded).toContain(comp3.body.id);
+    expect(res.body.succeeded).toContain(claimRes.body.id);
+    expect(res.body.failed).toHaveLength(0);
+  });
+
+  it('returns 400 when both arrays are empty', async () => {
+    await request(app)
+      .post('/api/approvals/bulk-approve')
+      .set('Authorization', `Bearer ${parentToken}`)
+      .send({ completionIds: [], claimIds: [] })
+      .expect(400)
+      .expect((res) => {
+        expect(res.body.error).toBe('no ids provided');
+      });
+  });
+
+  it('returns 400 when body is missing ids entirely', async () => {
+    await request(app)
+      .post('/api/approvals/bulk-approve')
+      .set('Authorization', `Bearer ${parentToken}`)
+      .send({})
+      .expect(400)
+      .expect((res) => {
+        expect(res.body.error).toBe('no ids provided');
+      });
+  });
+
+  it('chore from a different family fails, others succeed', async () => {
+    // Create a second parent with their own family and child/chore
+    const p2 = await request(app)
+      .post('/auth/google/callback')
+      .send({ idToken: 'otherbulk@example.com', familyName: 'OtherFam', timezone: 'UTC' })
+      .expect(200);
+    const otherFamilyId = p2.body.familyId;
+
+    const c2 = await request(app)
+      .post('/children')
+      .set('Authorization', `Bearer ${p2.body.token}`)
+      .send({ familyId: otherFamilyId, username: 'otherbulkkid', password: 'pw', displayName: 'Other Kid' })
+      .expect(201);
+
+    const ch4 = await request(app)
+      .post('/chores')
+      .set('Authorization', `Bearer ${p2.body.token}`)
+      .send({ familyId: otherFamilyId, name: 'Other Chore', value: 2, recurrence: 'daily', requiresApproval: true, assignedChildIds: [c2.body.id] })
+      .expect(201);
+
+    const comp4 = await request(app)
+      .post(`/chores/${ch4.body.id}/complete`)
+      .send({ childId: c2.body.id, date: '2026-01-05' })
+      .expect(200);
+
+    // Create a valid chore for our own family
+    const ch5 = await request(app)
+      .post('/chores')
+      .set('Authorization', `Bearer ${parentToken}`)
+      .send({ familyId, name: 'Own Chore', value: 7, recurrence: 'daily', requiresApproval: true, assignedChildIds: [childId] })
+      .expect(201);
+
+    const comp5 = await request(app)
+      .post(`/chores/${ch5.body.id}/complete`)
+      .send({ childId, date: '2026-01-05' })
+      .expect(200);
+
+    // Bulk approve: own completion should succeed, other family's completion should fail
+    const res = await request(app)
+      .post('/api/approvals/bulk-approve')
+      .set('Authorization', `Bearer ${parentToken}`)
+      .send({ completionIds: [comp5.body.id, comp4.body.id] })
+      .expect(200);
+
+    expect(res.body.succeeded).toContain(comp5.body.id);
+    // comp4 belongs to a different family — should fail
+    const failedIds = res.body.failed.map((f: any) => f.id);
+    expect(failedIds).toContain(comp4.body.id);
+    expect(res.body.succeeded).not.toContain(comp4.body.id);
+  });
+
+  it('non-parent token gets 401/403', async () => {
+    // Login as child
+    const childLoginRes = await request(app)
+      .post('/auth/child/login')
+      .send({ username: 'bulkkid', password: 'pw' })
+      .expect(200);
+    const childToken = childLoginRes.body.token;
+
+    const res = await request(app)
+      .post('/api/approvals/bulk-approve')
+      .set('Authorization', `Bearer ${childToken}`)
+      .send({ completionIds: ['some-id'] });
+
+    expect([401, 403]).toContain(res.status);
+  });
+
+  it('no auth token gets 401', async () => {
+    const res = await request(app)
+      .post('/api/approvals/bulk-approve')
+      .send({ completionIds: ['some-id'] });
+
+    expect([401, 403]).toContain(res.status);
+  });
+
+  it('partial failure reported correctly in response', async () => {
+    // Create one valid completion and include one non-existent id
+    const ch6 = await request(app)
+      .post('/chores')
+      .set('Authorization', `Bearer ${parentToken}`)
+      .send({ familyId, name: 'Partial Chore', value: 6, recurrence: 'daily', requiresApproval: true, assignedChildIds: [childId] })
+      .expect(201);
+
+    const comp6 = await request(app)
+      .post(`/chores/${ch6.body.id}/complete`)
+      .send({ childId, date: '2026-01-10' })
+      .expect(200);
+
+    const fakeId = 'comp_does_not_exist_99999';
+
+    const res = await request(app)
+      .post('/api/approvals/bulk-approve')
+      .set('Authorization', `Bearer ${parentToken}`)
+      .send({ completionIds: [comp6.body.id, fakeId] })
+      .expect(200);
+
+    expect(res.body.succeeded).toContain(comp6.body.id);
+    const failedIds = res.body.failed.map((f: any) => f.id);
+    expect(failedIds).toContain(fakeId);
+    // The failed entry should have an error message
+    const failEntry = res.body.failed.find((f: any) => f.id === fakeId);
+    expect(failEntry).toBeDefined();
+    expect(typeof failEntry.error).toBe('string');
+  });
+});

--- a/web/src/routes/ParentDashboard.tsx
+++ b/web/src/routes/ParentDashboard.tsx
@@ -1359,26 +1359,41 @@ export default function ParentDashboard() {
                   <div className="text-muted">No pending approvals.</div>
                 ) : (
                   <div className="table-responsive">
-                    <div className="d-flex justify-content-end mb-2 gap-2">
+                    <div className="d-flex justify-content-end mb-2 gap-2 flex-wrap align-items-center">
                       <button
                         className="btn btn-sm btn-outline-secondary"
                         onClick={() => setBulk(Object.fromEntries(approvals.map((a) => [a.id, true])))}
                       >
                         Select all
                       </button>
-                      <button
-                        className="btn btn-sm btn-success"
-                        onClick={async () => {
-                          const ids = approvals.filter((a) => bulk[a.id]).map((a) => a.id);
-                          if (ids.length === 0) return;
-                          await fetch('/approvals/bulk-approve', { method: 'POST', headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` }, body: JSON.stringify({ familyId: selectedFamily!.id, ids }) });
-                          await refreshApprovals();
-                          await refreshWeekly();
-                          setBulk({});
-                        }}
-                      >
-                        Approve selected
-                      </button>
+                      {approvals.filter((a) => bulk[a.id]).length > 0 && (
+                        <button
+                          className="btn btn-sm btn-success"
+                          onClick={async () => {
+                            const ids = approvals.filter((a) => bulk[a.id]).map((a) => a.id);
+                            if (ids.length === 0) return;
+                            try {
+                              const res = await fetch('/api/approvals/bulk-approve', {
+                                method: 'POST',
+                                headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+                                body: JSON.stringify({ completionIds: ids }),
+                              });
+                              const data = await res.json();
+                              const succeededCount = data.succeeded?.length ?? 0;
+                              const failedCount = data.failed?.length ?? 0;
+                              if (succeededCount > 0) push('success', `Approved ${succeededCount} chore${succeededCount !== 1 ? 's' : ''}`);
+                              if (failedCount > 0) push('warning', `${failedCount} item${failedCount !== 1 ? 's' : ''} could not be approved`);
+                            } catch {
+                              push('error', 'Bulk approve failed');
+                            }
+                            await refreshApprovals();
+                            await refreshWeekly();
+                            setBulk({});
+                          }}
+                        >
+                          Approve Selected ({approvals.filter((a) => bulk[a.id]).length})
+                        </button>
+                      )}
                       <button
                         className="btn btn-sm btn-outline-danger"
                         onClick={async () => {


### PR DESCRIPTION
## Summary

Final feature to reach MVP-complete. Adds bulk approval of chores and bonus claims from the parent approvals queue.

- **New `POST /api/approvals/bulk-approve`** endpoint — accepts `{ completionIds?, claimIds? }`, processes all items independently, returns `{ succeeded, failed }` for partial-failure handling
- **Select-all UI** in the Chores tab of the approvals queue — checkbox per item + "Approve Selected (N)" button that appears when ≥1 selected; success/warning toasts; clears selection after approval
- **8 new tests** covering: bulk chore approve, chore + bonus mix, empty body (400), cross-family rejection, partial failure reporting, and auth guards — 95 total passing

## Test plan

- [ ] `cd api && npm test` → 95 tests, all passing
- [ ] `cd web && npm run build` → clean TypeScript build
- [ ] Parent approvals queue: select 2+ pending chores → "Approve Selected (2)" button appears → click → both approved, toast shown, list refreshes
- [ ] Select all checkbox selects/deselects all items
- [ ] Individual Approve/Reject buttons still work as before
- [ ] `POST /api/approvals/bulk-approve` with empty body → 400
- [ ] Child token → 401

🤖 Generated with [Claude Code](https://claude.com/claude-code)