### PR TITLE
fix: uploaded avatars and patterns not displaying after save

### DIFF
--- a/web/src/routes/ChildDashboard.tsx
+++ b/web/src/routes/ChildDashboard.tsx
@@ -52,7 +52,8 @@ export default function ChildDashboard() {
     const u = child?.avatarUrl || null;
     if (!u) return null;
     if (u.startsWith('/uploads/serve')) {
-      
+      const tok = localStorage.getItem('childToken');
+      if (tok) return `${u}&token=${encodeURIComponent(tok)}`;
     }
     return u;
   }, [child]);
@@ -65,6 +66,13 @@ export default function ChildDashboard() {
 
 
   function dbg(label: string, data?: any) { try { console.log('[Profile]', label, data ?? ''); } catch {} }
+
+  // Append the child auth token to /uploads/serve URLs so <img> tags can authenticate
+  function serveImgUrl(url: string): string {
+    if (!url.startsWith('/uploads/serve')) return url;
+    const tok = localStorage.getItem('childToken');
+    return tok ? `${url}&token=${encodeURIComponent(tok)}` : url;
+  }
 
 
     async function uploadToS3(scope: 'avatars' | 'patterns' | 'goals', file: File): Promise<{ key: string; url: string }>{
@@ -83,7 +91,10 @@ export default function ChildDashboard() {
       Object.entries(data.post.fields as Record<string,string>).forEach(([k, v]) => fd.append(k, v));
       fd.append('file', file);
       dbg('upload:post:start', { url: data.post.url });
-      await fetch(data.post.url, { method: 'POST', body: fd, mode: 'no-cors' });
+      // Same-origin local uploads use 'cors' so errors are readable; cross-origin S3 needs 'no-cors'
+      const uploadMode = data.post.url.startsWith('/') ? 'cors' : 'no-cors';
+      const uploadRes = await fetch(data.post.url, { method: 'POST', body: fd, mode: uploadMode });
+      if (uploadMode === 'cors' && !uploadRes.ok) { dbg('upload:post:fail', uploadRes.status); throw new Error('upload failed: ' + uploadRes.status); }
       dbg('upload:post:done');
       dbg('complete:request', { key: data.key, scope });
       const rec = await fetch('/uploads/complete', {
@@ -1099,7 +1110,7 @@ export default function ChildDashboard() {
                           
                           setSelectedAvatarUrl(a.url);
                         }}>
-                          <img src={a.url} alt="uploaded avatar" style={{ width: 28, height: 28 }} />
+                          <img src={serveImgUrl(a.url)} alt="uploaded avatar" style={{ width: 28, height: 28 }} />
                         </button>
                       ))}
                       <div className="d-flex align-items-center gap-2">
@@ -1148,7 +1159,7 @@ export default function ChildDashboard() {
                             document.body.classList.add('cute-bg-on');
                             setCuteBg(true);
                           }}>
-                            <img src={patt.url} alt="uploaded pattern" style={{ width: 28, height: 28 }} />
+                            <img src={serveImgUrl(patt.url)} alt="uploaded pattern" style={{ width: 28, height: 28 }} />
                           </button>
                         ))}
                         <div className="d-flex align-items-center gap-2">


### PR DESCRIPTION
## Problem

Uploaded avatar and background pattern images showed as broken `?` tiles immediately after saving, and on every subsequent login.

## Root Cause

`/api/uploads/serve` enforces ownership via Bearer token auth — but `<img src="...">` tags load images without any auth headers, causing every request to return `401`.

Three bugs contributed:

1. **`avatarSrc` useMemo had an empty `if` block** — clearly meant to append `?token=` to serve URLs for the top bar avatar, but was never filled in
2. **Avatar picker tiles and pattern tiles** used the raw `/uploads/serve?key=...` URL with no token, so the broken images appeared in the profile editor too
3. **Local uploads used `mode: 'no-cors'`** — necessary for cross-origin S3 presigned POSTs, but wrong for same-origin `/api/uploads/local` requests; errors were silently swallowed

## Fix (`ChildDashboard.tsx`)

- Fill in the empty `avatarSrc` block to append `&token=<jwt>` when the URL is a serve URL
- Add `serveImgUrl()` helper that appends the token at render time; used on all uploaded image `<img>` tags
- Use `mode: 'cors'` for same-origin upload URLs so failures throw correctly

**Note:** The stored `avatarUrl` field intentionally keeps the clean URL (no token). The token is appended only at display time from localStorage, since tokens can expire.

## Test plan

- [ ] Upload an avatar → tile appears immediately in picker ✓
- [ ] Save profile → avatar shows in top bar ✓
- [ ] Log out and back in → avatar still shows ✓
- [ ] Upload a background pattern → pattern tile renders correctly ✓
- [ ] `cd web && npm run build` → clean build ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)