### PR TITLE
fix: correct local storage URLs and add Vite dev proxy

### DIFF
--- a/api/src/storage.local.ts
+++ b/api/src/storage.local.ts
@@ -30,7 +30,7 @@ export class LocalStorage implements StorageProvider {
 
   async presignPost(opts: { key: string; contentType: string; expiresIn?: number }): Promise<PresignPostResult> {
     return {
-      url: '/api/uploads/local',
+      url: '/uploads/local',
       fields: { key: opts.key },
       key: opts.key,
       driver: 'local',
@@ -50,7 +50,7 @@ export class LocalStorage implements StorageProvider {
   }
 
   publicUrl(key: string): string {
-    return `/api/uploads/serve?key=${encodeURIComponent(key)}`;
+    return `/uploads/serve?key=${encodeURIComponent(key)}`;
   }
 
   /** Expose uploadDir for use by the upload endpoint */

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,8 +1,34 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
+const API_TARGET = process.env.VITE_API_URL || 'http://localhost:3000';
+
+// Paths that should be proxied to the Express API in dev mode.
+// In production the API serves web/dist directly so no proxy is needed.
+const proxyPaths = [
+  '/api',
+  '/auth',
+  '/uploads',
+  '/bank',
+  '/children',
+  '/chores',
+  '/families',
+  '/savers',
+  '/bonuses',
+  '/me',
+  '/config',
+  '/healthz',
+  '/version',
+  '/tokens',
+];
+
 export default defineConfig({
   plugins: [react()],
+  server: {
+    proxy: Object.fromEntries(
+      proxyPaths.map((p) => [p, { target: API_TARGET, changeOrigin: true }])
+    ),
+  },
   test: {
     globals: true,
     environment: 'jsdom',


### PR DESCRIPTION
## Problems

Two bugs introduced with the local storage driver:

**1. Wrong URL paths in `storage.local.ts`**

`presignPost` returned `/api/uploads/local` and `publicUrl` returned `/api/uploads/serve?key=...`, but `uploadRoutes` is mounted **without** the `/api` prefix in `app.ts` (`app.use(uploadRoutes(...))`). This caused 404s for both the upload POST and every subsequent image load.

**2. No dev proxy in `vite.config.ts`**

In `npm run dev` mode, Vite runs on port 5173 and Express on port 3000. Without a proxy, all API calls (`/uploads/*`, `/bank/*`, `/children/*`, etc.) hit the Vite server and 404. Added a `server.proxy` config forwarding all API paths to `http://localhost:3000` (overridable via `VITE_API_URL`).

## Changes

- `api/src/storage.local.ts` — `/api/uploads/local` → `/uploads/local`; `/api/uploads/serve` → `/uploads/serve`
- `web/vite.config.ts` — added `server.proxy` for all API path prefixes

## Test plan

- [ ] Upload an avatar → no 404 in console, image appears immediately
- [ ] Reload page → avatar still visible in top bar and picker
- [ ] `npm run dev` → API calls (`/bank/*`, `/uploads/*`, etc.) proxy correctly to Express on port 3000

🤖 Generated with [Claude Code](https://claude.com/claude-code)