### PR TITLE
feat: manual catalog item add + product links in shop

### DIFF
--- a/web/src/routes/ChildDashboard.tsx
+++ b/web/src/routes/ChildDashboard.tsx
@@ -744,6 +744,9 @@ export default function ChildDashboard() {
                         <div className="shop-card-body">
                           <div className="shop-card-name">{saver.name}</div>
                           <div className="shop-card-price"><GoldCoin size={18} /> {saver.target}</div>
+                          {catalogItem?.sourceUrl && (
+                            <a href={catalogItem.sourceUrl} target="_blank" rel="noopener noreferrer" className="shop-card-link">🔗 View item</a>
+                          )}
                           {canAfford ? (
                             catalogItem ? (
                               <button className="shop-buy-btn" onClick={() => setBuyConfirmItem(catalogItem)}>Buy Now! 🛍️</button>
@@ -813,6 +816,9 @@ export default function ChildDashboard() {
                           <div className="shop-card-name">{item.name}</div>
                           {item.description && <div className="shop-card-desc">{item.description}</div>}
                           <div className="shop-card-price"><GoldCoin size={18} /> {item.priceCoins}</div>
+                          {item.sourceUrl && (
+                            <a href={item.sourceUrl} target="_blank" rel="noopener noreferrer" className="shop-card-link">🔗 View item</a>
+                          )}
                           {canAfford ? (
                             <button className="shop-buy-btn" onClick={() => setBuyConfirmItem(item)}>Buy Now! 🛍️</button>
                           ) : existingSaver ? (

--- a/web/src/routes/ParentDashboard.tsx
+++ b/web/src/routes/ParentDashboard.tsx
@@ -68,6 +68,12 @@ export default function ParentDashboard() {
   const [catalogAddImage, setCatalogAddImage] = useState('');
   const [catalogAddPrice, setCatalogAddPrice] = useState('');
   const [catalogSaving, setCatalogSaving] = useState(false);
+  const [catalogManualOpen, setCatalogManualOpen] = useState(false);
+  const [catalogManualName, setCatalogManualName] = useState('');
+  const [catalogManualDesc, setCatalogManualDesc] = useState('');
+  const [catalogManualImage, setCatalogManualImage] = useState('');
+  const [catalogManualUrl, setCatalogManualUrl] = useState('');
+  const [catalogManualPrice, setCatalogManualPrice] = useState('');
 
   const doPreviewFetch = async (urlOverride?: string) => {
     const url = (urlOverride ?? catalogPreviewUrl).trim();
@@ -1399,10 +1405,78 @@ export default function ParentDashboard() {
                   )}
                 </div>
 
+                {/* Manual Add Form */}
+                <div className="mb-4">
+                  <button
+                    className="btn btn-outline-secondary btn-sm mb-2"
+                    onClick={() => setCatalogManualOpen((o) => !o)}
+                  >
+                    {catalogManualOpen ? '✕ Cancel Manual Add' : '✏️ Add Manually'}
+                  </button>
+                  {catalogManualOpen && (
+                    <div className="card bg-light">
+                      <div className="card-body">
+                        <div className="row g-2">
+                          <div className="col-12 col-md-6">
+                            <label className="form-label small mb-1">Name *</label>
+                            <input className="form-control form-control-sm" placeholder="e.g. LEGO Star Wars Set" value={catalogManualName} onChange={(e) => setCatalogManualName(e.target.value)} />
+                          </div>
+                          <div className="col-6 col-md-3">
+                            <label className="form-label small mb-1">Price (coins) *</label>
+                            <input type="number" min={1} className="form-control form-control-sm" value={catalogManualPrice} onChange={(e) => setCatalogManualPrice(e.target.value)} />
+                          </div>
+                          <div className="col-12">
+                            <label className="form-label small mb-1">Description</label>
+                            <textarea className="form-control form-control-sm" rows={2} value={catalogManualDesc} onChange={(e) => setCatalogManualDesc(e.target.value)} />
+                          </div>
+                          <div className="col-12 col-md-6">
+                            <label className="form-label small mb-1">Image URL</label>
+                            <input className="form-control form-control-sm" placeholder="https://..." value={catalogManualImage} onChange={(e) => setCatalogManualImage(e.target.value)} />
+                          </div>
+                          <div className="col-12 col-md-6">
+                            <label className="form-label small mb-1">Product Link (optional)</label>
+                            <input className="form-control form-control-sm" placeholder="https://..." value={catalogManualUrl} onChange={(e) => setCatalogManualUrl(e.target.value)} />
+                          </div>
+                        </div>
+                        <div className="d-flex gap-2 mt-3">
+                          <button
+                            className="btn btn-primary btn-sm"
+                            disabled={!catalogManualName || !catalogManualPrice || catalogSaving}
+                            onClick={async () => {
+                              setCatalogSaving(true);
+                              try {
+                                const r = await fetch(`/api/families/${selectedFamily?.id}/catalog`, {
+                                  method: 'POST',
+                                  headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+                                  body: JSON.stringify({
+                                    name: catalogManualName,
+                                    description: catalogManualDesc || undefined,
+                                    imageUrl: catalogManualImage || undefined,
+                                    sourceUrl: catalogManualUrl || undefined,
+                                    priceCoins: parseInt(catalogManualPrice, 10),
+                                  }),
+                                });
+                                if (r.ok) {
+                                  const created = await r.json();
+                                  setCatalogItems((prev) => [created, ...prev]);
+                                  setCatalogManualOpen(false);
+                                  setCatalogManualName(''); setCatalogManualDesc(''); setCatalogManualImage(''); setCatalogManualUrl(''); setCatalogManualPrice('');
+                                } else { const e = await r.json().catch(() => ({})); alert(e?.error || 'Save failed'); }
+                              } catch { alert('Save failed'); }
+                              finally { setCatalogSaving(false); }
+                            }}
+                          >{catalogSaving ? 'Saving...' : 'Save to Catalog'}</button>
+                          <button className="btn btn-outline-secondary btn-sm" onClick={() => setCatalogManualOpen(false)}>Cancel</button>
+                        </div>
+                      </div>
+                    </div>
+                  )}
+                </div>
+
                 {/* Catalog Items List */}
                 <h3 className="h6 mb-2">Items ({catalogItems.length})</h3>
                 {catalogItems.length === 0 ? (
-                  <div className="text-muted small">No items yet. Add one via URL above.</div>
+                  <div className="text-muted small">No items yet. Add one via URL above or manually.</div>
                 ) : (
                   <div className="table-responsive">
                     <table className="table table-sm align-middle">
@@ -1424,7 +1498,11 @@ export default function ParentDashboard() {
                               ) : <span style={{ fontSize: 24 }}>🛍️</span>}
                             </td>
                             <td>
-                              <div className="fw-semibold">{item.name}</div>
+                              <div className="fw-semibold">
+                                {item.sourceUrl
+                                  ? <a href={item.sourceUrl} target="_blank" rel="noopener noreferrer">{item.name}</a>
+                                  : item.name}
+                              </div>
                               {item.description && <div className="small text-muted">{item.description}</div>}
                             </td>
                             <td><span className="badge bg-warning text-dark">{item.priceCoins} 🪙</span></td>

--- a/web/src/styles/app-theme.css
+++ b/web/src/styles/app-theme.css
@@ -1173,6 +1173,16 @@
   color: #F59E0B;
   margin: 4px 0;
 }
+.shop-card-link {
+  display: inline-block;
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.5);
+  text-decoration: none;
+}
+.shop-card-link:hover {
+  color: rgba(255, 255, 255, 0.8);
+  text-decoration: underline;
+}
 .shop-buy-btn {
   display: block;
   width: 100%;


### PR DESCRIPTION
## Summary
- **Manual add in parent admin**: "✏️ Add Manually" button opens a form to add catalog items without fetching a URL — fill in name, price, description, image URL, and an optional product link
- **Product links in parent list**: Item names in the catalog table link to `sourceUrl` when present
- **"View item" link in child shop**: A subtle "🔗 View item" link appears on shop cards (both catalog browse and saving-for goals) when a product link is available, so kids can tap through to see the item in their browser

## Test plan
- [ ] In parent admin, click "✏️ Add Manually" and fill in a name + price — verify it saves and appears in the list
- [ ] Add an item with a product link — verify the name in the parent list is clickable
- [ ] In the child shop, tap "🔗 View item" on an item with a link — should open in a new tab
- [ ] Items without a link show no "View item" link

🤖 Generated with [Claude Code](https://claude.com/claude-code)