### PR TITLE
fix: bonus claim 409 — load existing claims on dashboard mount

### DIFF
--- a/api/src/repos.bonus.pg.ts
+++ b/api/src/repos.bonus.pg.ts
@@ -150,9 +150,17 @@ export class PgBonusRepo implements BonusRepository {
     return r.rows.map((row: any) => this.rowToClaim(row));
   }
 
+  async listClaimsByChild(childId: string): Promise<BonusClaim[]> {
+    const r = await this.pool.query(
+      'SELECT * FROM bonus_claims WHERE child_id=$1 ORDER BY created_at DESC',
+      [childId]
+    );
+    return r.rows.map((row: any) => this.rowToClaim(row));
+  }
+
   async hasChildClaimed(bonusId: string, childId: string): Promise<boolean> {
     const r = await this.pool.query(
-      'SELECT 1 FROM bonus_claims WHERE bonus_id=$1 AND child_id=$2 LIMIT 1',
+      "SELECT 1 FROM bonus_claims WHERE bonus_id=$1 AND child_id=$2 AND status != 'rejected' LIMIT 1",
       [bonusId, childId]
     );
     return (r.rowCount ?? 0) > 0;

--- a/api/src/repositories.ts
+++ b/api/src/repositories.ts
@@ -303,6 +303,7 @@ export interface BonusRepository {
   createClaim(claim: BonusClaim): Promise<BonusClaim>;
   getClaimById(id: string): Promise<BonusClaim | undefined>;
   listClaimsByBonus(bonusId: string): Promise<BonusClaim[]>;
+  listClaimsByChild(childId: string): Promise<BonusClaim[]>;
   listPendingClaimsByFamily(familyId: string): Promise<BonusClaim[]>;
   hasChildClaimed(bonusId: string, childId: string): Promise<boolean>;
   updateClaim(claim: BonusClaim): Promise<BonusClaim>;
@@ -372,9 +373,14 @@ export class InMemoryBonusRepo implements BonusRepository {
       (c) => c.status === 'pending' && bonusIds.includes(c.bonusId)
     );
   }
+  async listClaimsByChild(childId: string): Promise<BonusClaim[]> {
+    return Array.from(this.claims.values())
+      .filter((c) => c.childId === childId)
+      .sort((a, b) => (a.createdAt > b.createdAt ? -1 : 1));
+  }
   async hasChildClaimed(bonusId: string, childId: string): Promise<boolean> {
     return Array.from(this.claims.values()).some(
-      (c) => c.bonusId === bonusId && c.childId === childId
+      (c) => c.bonusId === bonusId && c.childId === childId && c.status !== 'rejected'
     );
   }
   async updateClaim(claim: BonusClaim): Promise<BonusClaim> {

--- a/api/src/routes/bonuses.ts
+++ b/api/src/routes/bonuses.ts
@@ -106,6 +106,14 @@ export function bonusRoutes(opts: {
     return res.status(204).send();
   });
 
+  // GET /children/:childId/bonus-claims (child only — own claims)
+  router.get('/children/:childId/bonus-claims', requireRole('child'), async (req: Request, res) => {
+    const actor = (req as AuthedRequest).user!;
+    if (actor.id !== req.params.childId) return res.status(403).json({ error: 'forbidden' });
+    const claims = await bonus.listClaimsByChild(actor.id);
+    return res.json(claims);
+  });
+
   // POST /bonuses/:id/claim (child only)
   router.post('/bonuses/:id/claim', requireRole('child'), async (req: Request, res) => {
     const actor = (req as AuthedRequest).user!;

--- a/web/src/routes/ChildDashboard.tsx
+++ b/web/src/routes/ChildDashboard.tsx
@@ -224,12 +224,16 @@ export default function ChildDashboard() {
           setBalance(b.balance);
           setLedger(b.entries || []);
         }
-        // Fetch bonuses
+        // Fetch bonuses + my own claims
         try {
           const bonusToken = localStorage.getItem('childToken');
-          const rBonuses = await fetch(`/api/families/${data.familyId}/bonuses`, { headers: { Authorization: bonusToken ? `Bearer ${bonusToken}` : '' } });
+          const [rBonuses, rClaims] = await Promise.all([
+            fetch(`/api/families/${data.familyId}/bonuses`, { headers: { Authorization: bonusToken ? `Bearer ${bonusToken}` : '' } }),
+            fetch(`/api/children/${data.id}/bonus-claims`, { headers: { Authorization: bonusToken ? `Bearer ${bonusToken}` : '' } }),
+          ]);
           setBonuses(rBonuses.ok ? await rBonuses.json() : []);
-        } catch { setBonuses([]); }
+          setMyBonusClaims(rClaims.ok ? await rClaims.json() : []);
+        } catch { setBonuses([]); setMyBonusClaims([]); }
         try {
           const tok2 = localStorage.getItem('childToken');
           const rCatalog = await fetch(`/api/families/${data.familyId}/catalog`, { headers: { Authorization: tok2 ? `Bearer ${tok2}` : '' } });
@@ -702,7 +706,12 @@ export default function ChildDashboard() {
                               push('success', 'Bonus claimed! Waiting for parent approval.');
                               const rBonuses = await fetch(`/api/families/${child?.familyId}/bonuses`, { headers: { Authorization: tok ? `Bearer ${tok}` : '' } });
                               if (rBonuses.ok) setBonuses(await rBonuses.json());
-                            } else { push('error', 'Claim failed'); }
+                            } else if (r.status === 409) {
+                              push('error', 'Already submitted — waiting for approval!');
+                              setClaimingBonusId(null); setClaimNote('');
+                            } else {
+                              push('error', 'Claim failed. Please try again.');
+                            }
                           }}>Submit</button>
                           <button className="btn btn-sm btn-outline-secondary" onClick={() => { setClaimingBonusId(null); setClaimNote(''); }}>✕</button>
                         </div>


### PR DESCRIPTION
## Summary
- **Root cause**: `myBonusClaims` was always empty on page load — no API endpoint existed to fetch a child's own past claims. The UI "already claimed" guard never fired across sessions, so clicking Claim hit a 409 from the API.
- Added `GET /children/:childId/bonus-claims` endpoint (child auth) + `listClaimsByChild()` in the repo
- Now fetches existing claims on `ChildDashboard` mount so the Claim button correctly hides for already-claimed one-time bonuses
- Fixed `hasChildClaimed` to exclude rejected claims — children can now re-claim a rejected bonus
- Improved 409 error toast: "Already submitted — waiting for approval!" instead of generic "Claim failed"

## Test plan
- [ ] Child logs in — previously claimed one-time bonus shows "Claimed ✓" without a Claim button
- [ ] Un-claimed bonus still shows Claim button and submits successfully
- [ ] Rejected bonus allows re-claiming
- [ ] API logs show no more 409s on initial claim

🤖 Generated with [Claude Code](https://claude.com/claude-code)