### PR TITLE
fix: cash register ka-ching sound (#31)

### DIFF
--- a/web/src/coinSound.ts
+++ b/web/src/coinSound.ts
@@ -1,28 +1,43 @@
-/** Play a synthesized coin-ding sound using the Web Audio API. */
+/** Play a cash-register "ka-ching" sound using the Web Audio API. */
 export function playCoinSound(): void {
   try {
     const ctx = new (window.AudioContext || (window as any).webkitAudioContext)();
+    const now = ctx.currentTime;
 
-    function playTone(freq: number, gainPeak: number, startTime: number, duration: number) {
+    // "ka" — short percussive mechanical click (triangle wave sweep down)
+    const click = ctx.createOscillator();
+    const clickGain = ctx.createGain();
+    click.connect(clickGain);
+    clickGain.connect(ctx.destination);
+    click.type = 'triangle';
+    click.frequency.setValueAtTime(200, now);
+    click.frequency.exponentialRampToValueAtTime(80, now + 0.045);
+    clickGain.gain.setValueAtTime(0.45, now);
+    clickGain.gain.exponentialRampToValueAtTime(0.001, now + 0.045);
+    click.start(now);
+    click.stop(now + 0.05);
+
+    // "ching" — bright metallic bell, no pitch slide
+    function bell(freq: number, gainPeak: number, start: number, decay: number) {
       const osc = ctx.createOscillator();
-      const gain = ctx.createGain();
-      osc.connect(gain);
-      gain.connect(ctx.destination);
+      const g = ctx.createGain();
+      osc.connect(g);
+      g.connect(ctx.destination);
       osc.type = 'sine';
-      osc.frequency.setValueAtTime(freq, startTime);
-      osc.frequency.exponentialRampToValueAtTime(freq * 0.85, startTime + duration);
-      gain.gain.setValueAtTime(0, startTime);
-      gain.gain.linearRampToValueAtTime(gainPeak, startTime + 0.005);
-      gain.gain.exponentialRampToValueAtTime(0.001, startTime + duration);
-      osc.start(startTime);
-      osc.stop(startTime + duration);
+      osc.frequency.setValueAtTime(freq, start);
+      g.gain.setValueAtTime(0, start);
+      g.gain.linearRampToValueAtTime(gainPeak, start + 0.004);
+      g.gain.exponentialRampToValueAtTime(0.001, start + decay);
+      osc.start(start);
+      osc.stop(start + decay);
     }
 
-    const now = ctx.currentTime;
-    playTone(1318, 0.35, now, 0.4);          // E6 — bright coin fundamental
-    playTone(1976, 0.18, now, 0.25);         // B6 — metallic overtone
-    playTone(1318, 0.20, now + 0.07, 0.3);  // echo ping
-    setTimeout(() => ctx.close(), 700);
+    const ching = now + 0.03;
+    bell(2637, 0.40, ching, 0.55);        // E7 — primary bell tone
+    bell(3951, 0.18, ching, 0.40);        // B7 — bright overtone
+    bell(2637, 0.12, ching + 0.08, 0.35); // slight echo of fundamental
+
+    setTimeout(() => ctx.close(), 900);
   } catch {
     // AudioContext unavailable — fail silently
   }


### PR DESCRIPTION
## Summary
- Fixes #31 — the old E6/B6 sine tones with a downward frequency slide sounded like a weird scream
- Replaced with a proper cash register "ka-ching": a short percussive click (triangle wave sweep) followed by a bright metallic bell (E7 + B7 overtone) with no pitch slide and clean exponential decay

## Test plan
- [ ] Complete a chore as a child — sound should be a crisp cash register "ka-ching"
- [ ] No external audio files required (all synthesized via Web Audio API)

🤖 Generated with [Claude Code](https://claude.com/claude-code)