### PR TITLE
feat: immediate coin credit on chore approval, remove weekly payout (#33)

### DIFF
--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -100,7 +100,7 @@ export function createApp(deps?: { useDb?: boolean }) {
     bonusRepo.init().catch(() => {});
     const catalogRepo = new PgCatalogRepo(pool);
     catalogRepo.init().catch(() => {});
-    app.use(choresRoutes({ chores: choresRepo, families: repos, users: repos, activity: activityRepo }));
+    app.use(choresRoutes({ chores: choresRepo, families: repos, users: repos, bank: bankRepo, savers: saversRepo, activity: activityRepo }));
     app.use(bankRoutes({ bank: bankRepo, users: repos, families: repos, chores: choresRepo, savers: saversRepo, activity: activityRepo }));
     app.use(saversRoutes({ savers: saversRepo, users: repos, families: repos, bank: bankRepo }));
     app.use('/api', bonusRoutes({ bonus: bonusRepo, users: repos, families: repos, bank: bankRepo, savers: saversRepo }));
@@ -114,7 +114,7 @@ export function createApp(deps?: { useDb?: boolean }) {
   } else {
     const bonusRepo = new InMemoryBonusRepo();
     const activityRepo = new InMemoryActivityRepo();
-    app.use(choresRoutes({ chores: repos as any, families: repos, users: repos, activity: activityRepo }));
+    app.use(choresRoutes({ chores: repos as any, families: repos, users: repos, bank: repos as any, savers: repos as any, activity: activityRepo }));
     app.use(bankRoutes({ bank: repos as any, users: repos, families: repos, chores: repos as any, savers: repos as any, activity: activityRepo }));
     app.use(saversRoutes({ savers: repos as any, users: repos, families: repos, bank: repos as any }));
     app.use('/api', bonusRoutes({ bonus: bonusRepo, users: repos, families: repos, bank: repos as any, savers: repos as any }));

--- a/api/src/bank.types.ts
+++ b/api/src/bank.types.ts
@@ -12,6 +12,8 @@ export interface LedgerEntry {
     saverId?: string; // for reserve/release against a saver goal
     bonusId?: string;
     claimId?: string;
+    choreId?: string;
+    completionId?: string;
   };
   actor?: {
     role: 'parent' | 'child' | 'system';

--- a/api/src/routes/approvals.ts
+++ b/api/src/routes/approvals.ts
@@ -99,6 +99,20 @@ export function approvalsRoutes(opts: {
           status: 'approved',
         });
 
+        // Immediately credit the child
+        const choreEntry: LedgerEntry = {
+          id: `chore_entry_${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
+          childId: pending.childId,
+          amount: choreItem.value,
+          type: 'payout',
+          note: `Chore: ${choreItem.name}`,
+          meta: { choreId: choreItem.id, completionId: pending.id },
+          actor: { role: 'parent', id: actor.id },
+          createdAt: new Date().toISOString(),
+        };
+        await bank.addLedgerEntry(choreEntry);
+        if (savers) await applyAllocation(bank, savers, pending.childId, choreItem.value);
+
         // Emit activity
         await emitActivity(activity, {
           familyId: choreItem.familyId,

--- a/api/src/routes/chores.ts
+++ b/api/src/routes/chores.ts
@@ -1,7 +1,9 @@
 import { Request, Router } from 'express';
 import { AuthedRequest, requireRole } from '../middleware/auth';
-import { ActivityRepository, ChoresRepository, FamiliesRepository, UsersRepository } from '../repositories';
+import { ActivityRepository, BankRepository, ChoresRepository, FamiliesRepository, SaversRepository, UsersRepository } from '../repositories';
 import { Chore, Completion } from '../chores.types';
+import { LedgerEntry } from '../bank.types';
+import { applyAllocation } from '../alloc';
 import { emitActivity } from '../activity';
 import { llm } from '../llm';
 
@@ -68,9 +70,9 @@ async function assignEmoji(chore: Chore, choresRepo: ChoresRepository): Promise<
   }
 }
 
-export function choresRoutes(opts: { chores: ChoresRepository; families: FamiliesRepository; users: UsersRepository; activity?: ActivityRepository }) {
+export function choresRoutes(opts: { chores: ChoresRepository; families: FamiliesRepository; users: UsersRepository; bank?: BankRepository; savers?: SaversRepository; activity?: ActivityRepository }) {
   const router = Router();
-  const { chores, families, users, activity } = opts;
+  const { chores, families, users, bank, savers, activity } = opts;
 
   // Parent creates chore
   router.post('/chores', requireRole('parent'), async (req: Request, res) => {
@@ -286,6 +288,21 @@ export function choresRoutes(opts: { chores: ChoresRepository; families: Familie
     await chores.deleteCompletion(pending.id);
     await chores.createCompletion({ ...pending, id: `comp_${Date.now()}`, status: 'approved' });
     const approvedChore = await chores.getChoreById(pending.choreId);
+    // Immediately credit the child
+    if (bank && approvedChore) {
+      const entry: LedgerEntry = {
+        id: `chore_entry_${Date.now()}`,
+        childId: pending.childId,
+        amount: approvedChore.value,
+        type: 'payout',
+        note: `Chore: ${approvedChore.name}`,
+        meta: { choreId: approvedChore.id, completionId: pending.id },
+        actor: { role: 'parent', id: (req as AuthedRequest).user!.id },
+        createdAt: new Date().toISOString(),
+      };
+      await bank.addLedgerEntry(entry);
+      if (savers) await applyAllocation(bank, savers, pending.childId, approvedChore.value);
+    }
     await emitActivity(activity, {
       familyId,
       childId: pending.childId,

--- a/web/src/routes/ParentDashboard.tsx
+++ b/web/src/routes/ParentDashboard.tsx
@@ -437,16 +437,6 @@ export default function ParentDashboard() {
               <h2 className="h5">Family</h2>
               <p className="mb-1"><strong>Name:</strong> {selectedFamily?.name}</p>
               <p className="mb-3"><strong>Timezone:</strong> {selectedFamily?.timezone}</p>
-              <div className="mb-3">
-                <button
-                  className="btn btn-sm btn-outline-primary"
-                  type="button"
-                  disabled={payoutBusy || !selectedFamily}
-                  onClick={runPayout}
-                >
-                  {payoutBusy ? 'Paying…' : 'Run payout for this week'}
-                </button>
-              </div>
               <h3 className="h6">Parents</h3>
                 {parents.length === 0 ? (
                   <div className="text-muted mb-3">No parents yet.</div>


### PR DESCRIPTION
## Summary
- Fixes #33 — chore approval now immediately credits the child's account instead of waiting for a manual weekly payout
- Added `bank` + `savers` deps to `choresRoutes` so the single `/approvals/:id/approve` endpoint can write a ledger entry on approval
- Also added immediate ledger credit in `approvalsRoutes` bulk-approve for chore completions
- Added `choreId`/`completionId` to `LedgerEntry` meta type for traceability
- Removed the "Run payout for this week" button from the parent dashboard Manage tab (payout job kept for backward compatibility with existing data)

## Test plan
- [ ] Parent approves a chore → child's balance increases immediately (no payout needed)
- [ ] Bulk approve multiple chores → all children credited immediately
- [ ] "Run payout for this week" button no longer appears in Manage tab
- [ ] Auto-allocation (savers goals) still applies on chore approval

🤖 Generated with [Claude Code](https://claude.com/claude-code)