### PR TITLE
fix: poll balance/claims every 30s so parent approvals show live (#37)

### DIFF
--- a/web/src/routes/ChildDashboard.tsx
+++ b/web/src/routes/ChildDashboard.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState, useCallback } from 'react';
+import React, { useEffect, useMemo, useRef, useState, useCallback } from 'react';
 import '../styles/app-theme.css';
 import { playCoinSound } from '../coinSound';
 // Bootstrap Icons (SVGs as URLs for avatars/patterns)
@@ -269,6 +269,28 @@ export default function ChildDashboard() {
       try { document.body.classList.remove('cute-bg-on'); } catch {}
     };
   }, [nav]);
+
+  // Poll every 30s to pick up parent approvals (chores, bonuses) without a reload
+  useEffect(() => {
+    const interval = setInterval(async () => {
+      const cid = child?.id;
+      const fid = child?.familyId;
+      if (!cid || !fid) return;
+      const token = localStorage.getItem('childToken') ?? '';
+      const auth = token ? { Authorization: `Bearer ${token}` } : {};
+      try {
+        const [rb, rClaims, rToday] = await Promise.all([
+          fetch(`/bank/${cid}`),
+          fetch(`/api/children/${cid}/bonus-claims`, { headers: auth }),
+          fetch(`/children/${cid}/chores?scope=today`),
+        ]);
+        if (rb.ok) { const b = await rb.json(); setBalance(b.balance); setLedger(b.entries || []); }
+        if (rClaims.ok) setMyBonusClaims(await rClaims.json());
+        if (rToday.ok) setToday(await rToday.json());
+      } catch { /* ignore poll errors */ }
+    }, 30_000);
+    return () => clearInterval(interval);
+  }, [child]);
 
   useEffect(() => {
     document.body.classList.add('arcade-body');


### PR DESCRIPTION
## Summary
- The child dashboard only loaded balance and bonus claims on initial mount
- When a parent approved a bonus (or chore), the child had to manually reload to see the updated balance
- Added a 30-second polling interval that refreshes bank balance, ledger, bonus claims, and today's chores silently in the background

## Test plan
- [ ] Child claims a bonus
- [ ] Parent approves it from the dashboard
- [ ] Within 30 seconds the child's coin balance updates without a page reload
- [ ] Same for chore approvals

Fixes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)