### PR TITLE
fix: allow all hosts in Vite dev server (#14)

### DIFF
--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -25,6 +25,7 @@ const proxyPaths = [
 export default defineConfig({
   plugins: [react()],
   server: {
+    allowedHosts: true,
     proxy: Object.fromEntries(
       proxyPaths.map((p) => [p, { target: API_TARGET, changeOrigin: true }])
     ),


### PR DESCRIPTION
## Summary
- Set `server.allowedHosts: true` in `web/vite.config.ts` so the Vite dev server accepts requests from any Host header.
- Fixes access through external proxies like exe.dev (`river-anchor.exe.xyz`), which otherwise return `Blocked request. This host is not allowed.`

Closes #14.

## Test plan
- [ ] `npm run dev -w web` and access the app via the exe.dev proxy URL — page loads without the "Blocked request" error.
- [ ] Local access via `http://localhost:5173` still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)