### PR TITLE
fix: proxy /approvals and /activity in Vite dev (#15)

### DIFF
--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -20,6 +20,8 @@ const proxyPaths = [
   '/healthz',
   '/version',
   '/tokens',
+  '/approvals',
+  '/activity',
 ];
 
 export default defineConfig({


### PR DESCRIPTION
## Summary
- Add `/approvals` and `/activity` to the dev-server proxy list in `web/vite.config.ts`.
- `ParentDashboard` calls `fetch('/approvals?familyId=...')` at the root path (the approvals endpoints are mounted via the chores router at root, not under `/api`). Without a matching proxy entry, the request hits the Vite dev server (5173) and returns 404, manifesting as approvals not loading in dev.

Closes #15.

## Test plan
- [ ] `npm run dev` — log in as a parent, visit the dashboard; pending approvals list loads (no 404s in network tab for `/approvals?familyId=...`).
- [ ] Other existing routes (`/bank`, `/chores`, `/api/...`) still proxy correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)