### PR TITLE
fix: case-insensitive child usernames (#40)

### DIFF
--- a/api/src/repos.pg.ts
+++ b/api/src/repos.pg.ts
@@ -1,6 +1,6 @@
 import { Pool } from 'pg';
 import { ChildUser, Family, ParentUser } from './types';
-import { FamiliesRepository, UsersRepository } from './repositories';
+import { FamiliesRepository, UsersRepository, normalizeUsername } from './repositories';
 
 export class PgRepos implements UsersRepository, FamiliesRepository {
   private pool: Pool;
@@ -43,6 +43,11 @@ export class PgRepos implements UsersRepository, FamiliesRepository {
       ALTER TABLE children ADD COLUMN IF NOT EXISTS avatar_url TEXT;
       ALTER TABLE children ADD COLUMN IF NOT EXISTS theme_color TEXT;
     `);
+    // Case-insensitive usernames: lowercase any existing rows so the
+    // unique index continues to enforce global uniqueness after the
+    // application starts normalizing on write/read. Runs at most once
+    // per row — subsequent runs are no-ops.
+    await this.pool.query(`UPDATE children SET username = LOWER(username) WHERE username <> LOWER(username)`);
   }
 
   private async ensureReady() {
@@ -87,7 +92,7 @@ export class PgRepos implements UsersRepository, FamiliesRepository {
     await this.ensureReady();
     const c = await this.pool.query(
       'SELECT id, family_id, username, password_hash, display_name, avatar_url, theme_color FROM children WHERE username=$1',
-      [username]
+      [normalizeUsername(username)]
     );
     if (!c.rowCount) return undefined;
     const r = c.rows[0];
@@ -104,8 +109,9 @@ export class PgRepos implements UsersRepository, FamiliesRepository {
 
   async createChild(child: ChildUser): Promise<ChildUser> {
     await this.ensureReady();
+    const username = normalizeUsername(child.username);
     // pre-check global uniqueness for friendly error
-    const dup = await this.pool.query('SELECT 1 FROM children WHERE username=$1', [child.username]);
+    const dup = await this.pool.query('SELECT 1 FROM children WHERE username=$1', [username]);
     if (dup.rowCount) {
       const err: any = new Error('username taken');
       err.code = 409;
@@ -113,9 +119,9 @@ export class PgRepos implements UsersRepository, FamiliesRepository {
     }
     await this.pool.query(
       'INSERT INTO children(id, family_id, username, password_hash, display_name, avatar_url, theme_color) VALUES ($1,$2,$3,$4,$5,$6,$7)',
-      [child.id, child.familyId, child.username, child.passwordHash, child.displayName, child.avatarUrl ?? null, child.themeColor ?? null]
+      [child.id, child.familyId, username, child.passwordHash, child.displayName, child.avatarUrl ?? null, child.themeColor ?? null]
     );
-    return child;
+    return { ...child, username };
   }
 
   async updateChild(id: string, update: Partial<Pick<ChildUser, 'username' | 'passwordHash' | 'displayName' | 'avatarUrl' | 'themeColor'>>) {
@@ -123,15 +129,16 @@ export class PgRepos implements UsersRepository, FamiliesRepository {
     const cur = await this.pool.query('SELECT id, family_id, username, password_hash, display_name FROM children WHERE id=$1', [id]);
     if (!cur.rowCount) return undefined;
     const r = cur.rows[0];
-    if (update.username && update.username !== r.username) {
-      const dup = await this.pool.query('SELECT 1 FROM children WHERE family_id=$1 AND username=$2 AND id<>$3', [r.family_id, update.username, id]);
+    const normalizedUpdateUsername = update.username ? normalizeUsername(update.username) : undefined;
+    if (normalizedUpdateUsername && normalizedUpdateUsername !== r.username) {
+      const dup = await this.pool.query('SELECT 1 FROM children WHERE family_id=$1 AND username=$2 AND id<>$3', [r.family_id, normalizedUpdateUsername, id]);
       if (dup.rowCount) {
         const err: any = new Error('username taken');
         err.code = 409;
         throw err;
       }
     }
-    const nextUsername = update.username ?? r.username;
+    const nextUsername = normalizedUpdateUsername ?? r.username;
     const nextPw = update.passwordHash ?? r.password_hash;
     const nextName = update.displayName ?? r.display_name;
     const nextAvatar = update.avatarUrl ?? r.avatar_url ?? null;

--- a/api/src/repositories.ts
+++ b/api/src/repositories.ts
@@ -7,6 +7,14 @@ import { Bonus, BonusClaim } from './bonus.types';
 import { ActivityEntry } from './activity.types';
 import crypto from 'crypto';
 
+/**
+ * Normalize a username to its canonical (case-insensitive) form.
+ * Children log in case-insensitively: "Alex" and "alex" are the same account.
+ */
+export function normalizeUsername(username: string): string {
+  return username.toLowerCase();
+}
+
 export interface UsersRepository {
   getParentByEmail(email: string): Promise<ParentUser | undefined>;
   getParentById(id: string): Promise<ParentUser | undefined>;
@@ -86,40 +94,44 @@ export class InMemoryRepos implements UsersRepository, FamiliesRepository, Chore
   }
 
   async getChildByUsername(username: string) {
-    for (const c of this.children.values()) if (c.username === username) return c;
+    const target = normalizeUsername(username);
+    for (const c of this.children.values()) if (c.username === target) return c;
     return undefined;
   }
   async getChildById(id: string) {
     return this.children.get(id);
   }
   async createChild(child: ChildUser) {
+    const username = normalizeUsername(child.username);
     // global username uniqueness
-    for (const c of this.children.values()) if (c.username === child.username) {
+    for (const c of this.children.values()) if (c.username === username) {
       const err: any = new Error('username taken');
       err.code = 409;
       throw err;
     }
-    this.children.set(child.id, child);
+    const normalized = { ...child, username };
+    this.children.set(child.id, normalized);
     const fam = this.families.get(child.familyId);
     if (fam && !fam.childIds.includes(child.id)) {
       fam.childIds.push(child.id);
       this.families.set(fam.id, fam);
     }
-    return child;
+    return normalized;
   }
 
   async updateChild(id: string, update: Partial<Pick<ChildUser, 'username' | 'passwordHash' | 'displayName' | 'avatarUrl' | 'themeColor'>>) {
     const cur = this.children.get(id);
     if (!cur) return undefined;
-    if (update.username && update.username !== cur.username) {
+    const normalizedUpdateUsername = update.username ? normalizeUsername(update.username) : undefined;
+    if (normalizedUpdateUsername && normalizedUpdateUsername !== cur.username) {
       // uniqueness per family
       for (const c of this.children.values()) {
-        if (c.familyId === cur.familyId && c.username === update.username) {
+        if (c.familyId === cur.familyId && c.username === normalizedUpdateUsername) {
           throw Object.assign(new Error('username taken'), { code: 409 });
         }
       }
     }
-    const next = { ...cur, ...update } as ChildUser;
+    const next = { ...cur, ...update, ...(normalizedUpdateUsername ? { username: normalizedUpdateUsername } : {}) } as ChildUser;
     this.children.set(id, next);
     return next;
   }

--- a/api/tests/username.case-insensitive.test.ts
+++ b/api/tests/username.case-insensitive.test.ts
@@ -1,0 +1,44 @@
+import request from 'supertest';
+import { createApp } from '../src/app';
+
+describe('Case-insensitive child usernames (#40)', () => {
+  const app = createApp();
+  let parentToken = '';
+  let familyId = '';
+
+  beforeAll(async () => {
+    const r = await request(app)
+      .post('/auth/google/callback')
+      .send({ idToken: 'caseparent@example.com', familyName: 'Fam', timezone: 'UTC' })
+      .expect(200);
+    parentToken = r.body.token;
+    familyId = r.body.familyId;
+  });
+
+  it('stores a new username in lowercase regardless of input casing', async () => {
+    const r = await request(app)
+      .post('/children')
+      .set('Authorization', `Bearer ${parentToken}`)
+      .send({ familyId, username: 'MixedCase', password: 'pw', displayName: 'Mixed' })
+      .expect(201);
+    expect(r.body.username).toBe('mixedcase');
+  });
+
+  it('allows child login with any casing of an existing username', async () => {
+    for (const attempt of ['mixedcase', 'MIXEDCASE', 'MixedCase', 'mIxEdCaSe']) {
+      const r = await request(app)
+        .post('/auth/child/login')
+        .send({ username: attempt, password: 'pw' });
+      expect(r.status).toBe(200);
+      expect(r.body.child.username).toBe('mixedcase');
+    }
+  });
+
+  it('rejects creating a new child whose username differs only in case', async () => {
+    await request(app)
+      .post('/children')
+      .set('Authorization', `Bearer ${parentToken}`)
+      .send({ familyId, username: 'MIXEDCASE', password: 'pw', displayName: 'Dup' })
+      .expect(409);
+  });
+});


### PR DESCRIPTION
## Summary
- Kids were getting 401s on login when their typed casing didn't match what was saved. Now \"Alex\", \"alex\", and \"ALEX\" all resolve to the same account.
- Normalization lives at the repository boundary so every caller benefits:
  - New \`normalizeUsername()\` helper lowercases the input.
  - \`InMemoryRepos\` and \`PgRepos\` normalize in \`createChild\`, \`updateChild\`, and \`getChildByUsername\`.
  - \`PgRepos.init()\` runs a one-shot idempotent migration (\`UPDATE children SET username = LOWER(username) WHERE username <> LOWER(username)\`) so existing rows match the new invariant and the unique index still enforces global uniqueness.
- Route layer is unchanged — repos handle it.

Closes #40.

## Test plan
- [x] New \`username.case-insensitive.test.ts\` — create \"MixedCase\", login with 4 different casings, reject duplicate \"MIXEDCASE\".
- [x] Full suite: 103/103 passing (was 100 before, +3 new).
- [ ] On Supabase/Postgres: create a child \"Alex\", log in as \"alex\" and \"ALEX\" — both succeed.
- [ ] Existing mixed-case rows (if any) are lowercased on next API startup and still log in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)