### PR TITLE
hotfix: restore missing normalizeUsername import in PgRepos

### DIFF
--- a/api/src/repos.pg.ts
+++ b/api/src/repos.pg.ts
@@ -1,6 +1,6 @@
 import { Pool } from 'pg';
 import { ChildUser, Family, ParentUser } from './types';
-import { FamiliesRepository, UsersRepository } from './repositories';
+import { FamiliesRepository, UsersRepository, normalizeUsername } from './repositories';
 import { createPool } from './db';
 
 export class PgRepos implements UsersRepository, FamiliesRepository {


### PR DESCRIPTION
## Summary
Hotfix for a merge artifact between #43 and #44. Both PRs edited the imports at the top of \`api/src/repos.pg.ts\`:

- #43 (\`createPool\`) added \`import { createPool } from './db';\` as a new line.
- #44 (\`normalizeUsername\`) added \`normalizeUsername\` to the existing \`./repositories\` import.

When #44 merged on top of #43, git's auto-merge kept #43's version of the \`./repositories\` import line and silently dropped #44's addition. The call sites \`normalizeUsername(...)\` added by #44 were preserved, so every child login hitting the Postgres repo threw:

\`\`\`
ReferenceError: normalizeUsername is not defined
    at PgRepos.getChildByUsername (api/src/repos.pg.ts:94)
    at routes/auth.ts:44
\`\`\`

Tests didn't catch it because the in-memory repo lives in the same file as the helper and compiles fine regardless.

## Test plan
- [x] \`npm test -w api\` — 103/103 passing.
- [x] Live: scp'd fix to the VM, restarted API, \`POST /auth/child/login\` now returns 401 for bad creds instead of 500.

🤖 Generated with [Claude Code](https://claude.com/claude-code)