### PR TITLE
feat: replace child text password with numeric keypad PIN

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,11 +1,14 @@
 import React, { useCallback, useEffect, useId, useRef, useState } from 'react';
 import './styles/landing.css';
+import NumericKeypad from './components/NumericKeypad';
 
 export default function App() {
   const [googleClientId, setGoogleClientId] = useState<string | null>(null);
   const [dialog, setDialog] = useState<null | 'parent' | 'child'>(null);
   const [menuOpen, setMenuOpen] = useState(false);
   const [sticky, setSticky] = useState(false);
+  const [childPin, setChildPin] = useState('');
+  const [childUsername, setChildUsername] = useState('');
   const closeBtnRef = useRef<HTMLButtonElement | null>(null);
   const dialogTitleId = useId();
 
@@ -412,14 +415,14 @@ export default function App() {
       </footer>
 
       {/* ── DIALOGS ── */}
-      {dialog && <div className="lp-overlay" onClick={() => setDialog(null)} aria-hidden />}
+      {dialog && <div className="lp-overlay" onClick={() => { setDialog(null); setChildPin(''); setChildUsername(''); }} aria-hidden />}
       {dialog && (
         <div className="lp-modal" role="dialog" aria-modal="true" aria-labelledby={dialogTitleId}>
           <div className="lp-modal-card" onClick={e => e.stopPropagation()}>
             <button
               ref={closeBtnRef}
               className="lp-modal-close"
-              onClick={() => setDialog(null)}
+              onClick={() => { setDialog(null); setChildPin(''); setChildUsername(''); }}
               aria-label="Close"
             >×</button>
 
@@ -442,40 +445,52 @@ export default function App() {
               <>
                 <div className="lp-modal-icon" aria-hidden>🎮</div>
                 <h2 id={dialogTitleId}>Kid Sign In</h2>
-                <p className="lp-modal-sub">Welcome back, adventurer! Enter your username and password to continue your quest.</p>
+                <p className="lp-modal-sub">Welcome back, adventurer! Enter your username and PIN to continue your quest.</p>
                 <form
                   aria-label="Child Sign In Form"
                   onSubmit={async (e) => {
                     e.preventDefault();
-                    const username = (e.currentTarget.querySelector('#child-login-username') as HTMLInputElement)?.value;
-                    const password = (e.currentTarget.querySelector('#child-login-password') as HTMLInputElement)?.value;
+                    if (!childPin) return;
                     try {
                       const r = await fetch('/auth/child/login', {
                         method: 'POST',
                         headers: { 'Content-Type': 'application/json' },
-                        body: JSON.stringify({ username, password })
+                        body: JSON.stringify({ username: childUsername, password: childPin })
                       });
                       const data = await r.json();
                       if (r.ok && data.token) {
                         localStorage.setItem('childToken', data.token);
                         window.location.assign('/child');
                       } else {
-                        alert('Login failed — check your username and password!');
+                        setChildPin('');
+                        alert('Login failed — check your username and PIN!');
                       }
                     } catch {
+                      setChildPin('');
                       alert('Login failed — please try again!');
                     }
                   }}
                 >
                   <div className="lp-form-group">
                     <label htmlFor="child-login-username">Username</label>
-                    <input id="child-login-username" placeholder="Enter your username" autoComplete="username" />
+                    <input
+                      id="child-login-username"
+                      placeholder="Enter your username"
+                      autoComplete="username"
+                      value={childUsername}
+                      onChange={(e) => setChildUsername(e.target.value)}
+                    />
                   </div>
                   <div className="lp-form-group">
-                    <label htmlFor="child-login-password">Password</label>
-                    <input id="child-login-password" type="password" placeholder="Enter your password" autoComplete="current-password" />
+                    <label>PIN</label>
+                    <NumericKeypad value={childPin} onChange={setChildPin} maxLength={6} />
                   </div>
-                  <button className="lp-btn lp-btn-primary" type="submit" style={{ width: '100%', justifyContent: 'center', fontSize: 16, padding: '14px 20px', borderRadius: 12 }}>
+                  <button
+                    className="lp-btn lp-btn-primary"
+                    type="submit"
+                    disabled={!childUsername || childPin.length < 1}
+                    style={{ width: '100%', justifyContent: 'center', fontSize: 16, padding: '14px 20px', borderRadius: 12 }}
+                  >
                     Start My Quest 🚀
                   </button>
                 </form>

--- a/web/src/components/NumericKeypad.tsx
+++ b/web/src/components/NumericKeypad.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+
+interface NumericKeypadProps {
+  value: string;
+  onChange: (value: string) => void;
+  maxLength?: number;
+  /** Show dots for entered digits */
+  showDots?: boolean;
+}
+
+const KEYS = ['1', '2', '3', '4', '5', '6', '7', '8', '9', '', '0', '⌫'];
+
+export default function NumericKeypad({
+  value,
+  onChange,
+  maxLength = 6,
+  showDots = true,
+}: NumericKeypadProps) {
+  function handleKey(key: string) {
+    if (key === '⌫') {
+      onChange(value.slice(0, -1));
+    } else if (key === '') {
+      // empty slot — no-op
+    } else if (value.length < maxLength) {
+      onChange(value + key);
+    }
+  }
+
+  return (
+    <div className="kp-root">
+      {showDots && (
+        <div className="kp-dots" aria-label={`${value.length} digits entered`}>
+          {Array.from({ length: maxLength }).map((_, i) => (
+            <span
+              key={i}
+              className={`kp-dot${i < value.length ? ' kp-dot--filled' : ''}`}
+            />
+          ))}
+        </div>
+      )}
+
+      <div className="kp-grid" role="group" aria-label="Numeric keypad">
+        {KEYS.map((key, i) => {
+          const isEmpty = key === '';
+          const isBackspace = key === '⌫';
+          return (
+            <button
+              key={i}
+              type="button"
+              className={`kp-key${isEmpty ? ' kp-key--empty' : ''}${isBackspace ? ' kp-key--back' : ''}`}
+              onClick={() => handleKey(key)}
+              disabled={isEmpty}
+              aria-label={isBackspace ? 'Delete last digit' : isEmpty ? undefined : key}
+              tabIndex={isEmpty ? -1 : 0}
+            >
+              {key}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/PinInput.tsx
+++ b/web/src/components/PinInput.tsx
@@ -1,0 +1,43 @@
+import React, { useRef } from 'react';
+
+interface PinInputProps {
+  value: string;
+  onChange: (value: string) => void;
+  maxLength?: number;
+}
+
+/**
+ * Compact numeric PIN input for parent-facing forms.
+ * Accepts only digit characters, displays as dots.
+ */
+export default function PinInput({ value, onChange, maxLength = 6 }: PinInputProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  function handleChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const digits = e.target.value.replace(/\D/g, '').slice(0, maxLength);
+    onChange(digits);
+  }
+
+  return (
+    <div className="pin-input-wrap" onClick={() => inputRef.current?.focus()}>
+      <input
+        ref={inputRef}
+        type="tel"
+        inputMode="numeric"
+        pattern="[0-9]*"
+        value={value}
+        onChange={handleChange}
+        maxLength={maxLength}
+        className="pin-input-hidden"
+        aria-label="Numeric PIN"
+        autoComplete="off"
+      />
+      <div className="pin-input-dots" aria-hidden>
+        {Array.from({ length: maxLength }).map((_, i) => (
+          <span key={i} className={`pin-dot${i < value.length ? ' pin-dot--filled' : ''}`} />
+        ))}
+      </div>
+      <span className="pin-input-hint">{value.length}/{maxLength} digits</span>
+    </div>
+  );
+}

--- a/web/src/routes/ParentDashboard.tsx
+++ b/web/src/routes/ParentDashboard.tsx
@@ -3,6 +3,7 @@ import '../styles/app-theme.css';
 import { useToast } from '../components/Toast';
 import { useNavigate, useLocation } from 'react-router-dom';
 import TopBar from '../components/TopBar';
+import PinInput from '../components/PinInput';
 
 // Types for bonus/activity features
 interface Bonus { id: string; familyId: string; name: string; description?: string; value: number; claimType: 'one-time' | 'unlimited'; childIds?: string[]; active: boolean; createdAt: string; }
@@ -30,6 +31,7 @@ export default function ParentDashboard() {
   const [apiTokens, setApiTokens] = useState<Array<{ id: string; label?: string; createdAt: string; lastUsedAt?: string; expiresAt?: string | null }>>([]);
   const [newTokenLabel, setNewTokenLabel] = useState('');
   const [newTokenValue, setNewTokenValue] = useState<string | null>(null);
+  const [newChildPin, setNewChildPin] = useState('');
   const { push } = useToast();
   const [saversByChild, setSaversByChild] = useState<Record<string, any[]>>({});
   const [weekDayIndex, setWeekDayIndex] = useState(0); // mobile pager for Week Overview
@@ -335,19 +337,18 @@ export default function ParentDashboard() {
     e.preventDefault();
     if (!token || !selectedFamily) return;
     const username = (e.currentTarget.querySelector('#childUser') as HTMLInputElement).value;
-    const password = (e.currentTarget.querySelector('#childPw') as HTMLInputElement).value;
     const displayName = (e.currentTarget.querySelector('#childName') as HTMLInputElement).value;
     await fetch('/children', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
-      body: JSON.stringify({ familyId: selectedFamily.id, username, password, displayName })
+      body: JSON.stringify({ familyId: selectedFamily.id, username, password: newChildPin, displayName })
     });
     // refresh list
     const r = await fetch(`/families/${selectedFamily.id}/children`, { headers: { Authorization: `Bearer ${token}` } });
     if (r.ok) setChildren(await r.json());
     (e.currentTarget.querySelector('#childUser') as HTMLInputElement).value = '';
-    (e.currentTarget.querySelector('#childPw') as HTMLInputElement).value = '';
     (e.currentTarget.querySelector('#childName') as HTMLInputElement).value = '';
+    setNewChildPin('');
   };
 
   const handleRenameChild = async (id: string) => {
@@ -481,18 +482,19 @@ export default function ParentDashboard() {
                 <form className="row g-2" onSubmit={handleAddChild}>
                   <div className="col-12">
                     <label htmlFor="childName" className="form-label">Display name</label>
-                    <input id="childName" className="form-control" />
-                  </div>
-                  <div className="col-md-6">
-                    <label htmlFor="childUser" className="form-label">Username</label>
-                    <input id="childUser" className="form-control" />
-                  </div>
-                  <div className="col-md-6">
-                    <label htmlFor="childPw" className="form-label">Password</label>
-                    <input id="childPw" type="password" className="form-control" />
+                    <input id="childName" className="form-control" required />
                   </div>
                   <div className="col-12">
-                    <button className="btn btn-success" type="submit">Add child</button>
+                    <label htmlFor="childUser" className="form-label">Username</label>
+                    <input id="childUser" className="form-control" required />
+                  </div>
+                  <div className="col-12">
+                    <label className="form-label">PIN (numbers only)</label>
+                    <PinInput value={newChildPin} onChange={setNewChildPin} maxLength={6} />
+                    <div className="form-text">Set a numeric PIN the child will use to sign in.</div>
+                  </div>
+                  <div className="col-12">
+                    <button className="btn btn-success" type="submit" disabled={newChildPin.length < 1}>Add child</button>
                   </div>
                 </form>
               </div>

--- a/web/src/routes/Settings.tsx
+++ b/web/src/routes/Settings.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import TopBar from '../components/TopBar';
 import { useToast } from '../components/Toast';
+import PinInput from '../components/PinInput';
 import '../styles/app-theme.css';
 
 const TIMEZONES = [
@@ -42,6 +43,11 @@ export default function Settings() {
 
   // Delete child confirmation
   const [deletingChild, setDeletingChild] = useState<string | null>(null);
+
+  // PIN change state
+  const [changingPinChild, setChangingPinChild] = useState<string | null>(null);
+  const [newPin, setNewPin] = useState('');
+  const [savingPin, setSavingPin] = useState(false);
 
   // Token creation state
   const [showCreateToken, setShowCreateToken] = useState(false);
@@ -185,6 +191,29 @@ export default function Settings() {
       }
     } catch {
       push('error', 'Failed to delete child');
+    }
+  }
+
+  async function handleChangePin(id: string) {
+    if (!token || !newPin) return;
+    setSavingPin(true);
+    try {
+      const r = await fetch(`/children/${id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+        body: JSON.stringify({ password: newPin }),
+      });
+      if (r.ok) {
+        setChangingPinChild(null);
+        setNewPin('');
+        push('success', 'PIN updated');
+      } else {
+        push('error', 'Failed to update PIN');
+      }
+    } catch {
+      push('error', 'Failed to update PIN');
+    } finally {
+      setSavingPin(false);
     }
   }
 
@@ -333,12 +362,18 @@ export default function Settings() {
                             )}
                           </div>
                           {renamingChild !== c.id && (
-                            <div className="d-flex gap-2">
+                            <div className="d-flex gap-2 flex-wrap">
                               <button
                                 className="btn btn-sm btn-outline-secondary"
                                 onClick={() => { setRenamingChild(c.id); setRenameValue(c.displayName || ''); }}
                               >
                                 Rename
+                              </button>
+                              <button
+                                className="btn btn-sm btn-outline-primary"
+                                onClick={() => { setChangingPinChild(c.id); setNewPin(''); setDeletingChild(null); }}
+                              >
+                                Change PIN
                               </button>
                               <button
                                 className="btn btn-sm btn-outline-danger"
@@ -349,6 +384,29 @@ export default function Settings() {
                             </div>
                           )}
                         </div>
+
+                        {/* PIN change inline */}
+                        {changingPinChild === c.id && (
+                          <div className="mt-2 p-3 border rounded" style={{ background: 'rgba(var(--bs-primary-rgb), 0.05)' }}>
+                            <div className="small fw-semibold mb-2">New PIN for {c.displayName}</div>
+                            <PinInput value={newPin} onChange={setNewPin} maxLength={6} />
+                            <div className="d-flex gap-2 mt-2">
+                              <button
+                                className="btn btn-sm btn-primary"
+                                disabled={newPin.length < 1 || savingPin}
+                                onClick={() => handleChangePin(c.id)}
+                              >
+                                {savingPin ? 'Saving…' : 'Save PIN'}
+                              </button>
+                              <button
+                                className="btn btn-sm btn-outline-secondary"
+                                onClick={() => { setChangingPinChild(null); setNewPin(''); }}
+                              >
+                                Cancel
+                              </button>
+                            </div>
+                          </div>
+                        )}
 
                         {/* Delete confirmation inline */}
                         {deletingChild === c.id && (

--- a/web/src/styles/app-theme.css
+++ b/web/src/styles/app-theme.css
@@ -1317,3 +1317,46 @@
   color: var(--text-muted);
   white-space: nowrap;
 }
+
+/* ── PinInput (parent-facing numeric PIN setter) ── */
+.pin-input-wrap {
+  position: relative;
+  display: inline-flex;
+  flex-direction: column;
+  gap: 6px;
+  cursor: text;
+}
+.pin-input-hidden {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+  width: 1px;
+  height: 1px;
+}
+.pin-input-dots {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  padding: 10px 14px;
+  background: var(--card-bg, #fff);
+  border: 1px solid var(--border-color, #dee2e6);
+  border-radius: 8px;
+  min-width: 180px;
+}
+.pin-dot {
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  border: 2px solid var(--text-muted, #6c757d);
+  background: transparent;
+  transition: background 120ms, border-color 120ms;
+  flex-shrink: 0;
+}
+.pin-dot--filled {
+  background: var(--primary, #0d6efd);
+  border-color: var(--primary, #0d6efd);
+}
+.pin-input-hint {
+  font-size: 11px;
+  color: var(--text-muted, #6c757d);
+}

--- a/web/src/styles/landing.css
+++ b/web/src/styles/landing.css
@@ -928,3 +928,86 @@
   border-radius: 999px;
 }
 @media (min-width: 769px) { .lp-hamburger { display: none; } }
+
+/* ── Numeric Keypad (child login) ── */
+.kp-root {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 20px;
+}
+
+/* PIN dot indicators */
+.kp-dots {
+  display: flex;
+  gap: 12px;
+  justify-content: center;
+}
+.kp-dot {
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  border: 2px solid rgba(255, 255, 255, 0.3);
+  background: transparent;
+  transition: background 150ms, border-color 150ms, transform 120ms;
+}
+.kp-dot--filled {
+  background: var(--lp-cherry);
+  border-color: var(--lp-cherry);
+  transform: scale(1.15);
+}
+
+/* 3-column key grid */
+.kp-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 12px;
+  width: 100%;
+  max-width: 280px;
+}
+
+.kp-key {
+  aspect-ratio: 1;
+  min-height: 64px;
+  border-radius: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  background: rgba(255, 255, 255, 0.07);
+  color: #fff;
+  font-family: 'Fredoka', sans-serif;
+  font-size: 26px;
+  font-weight: 600;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 120ms, transform 80ms, box-shadow 120ms;
+  -webkit-tap-highlight-color: transparent;
+  user-select: none;
+}
+.kp-key:hover:not(:disabled) {
+  background: rgba(255, 255, 255, 0.14);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
+}
+.kp-key:active:not(:disabled) {
+  transform: scale(0.93);
+  background: rgba(232, 41, 76, 0.25);
+}
+.kp-key--back {
+  font-size: 22px;
+  color: rgba(255, 255, 255, 0.6);
+}
+.kp-key--back:hover:not(:disabled) {
+  color: #fff;
+  background: rgba(255, 255, 255, 0.1);
+}
+.kp-key--empty {
+  background: transparent;
+  border-color: transparent;
+  cursor: default;
+  pointer-events: none;
+}
+
+@media (min-width: 400px) {
+  .kp-grid { max-width: 300px; }
+  .kp-key { min-height: 72px; font-size: 28px; }
+}


### PR DESCRIPTION
Closes #46

## What changed

Children now sign in using a touch-friendly numeric keypad instead of a typed password. Parents set and update PINs via a compact dot-display input in the Parent Dashboard and Settings.

### Child login (`App.tsx`)
The password text field is replaced with a `NumericKeypad` — a 3×4 button grid with large tap targets (64px+ per key) and dot indicators showing digits entered. Styled to match the existing arcade theme (Fredoka font, cherry/gold tokens).

### Add child form (`ParentDashboard.tsx`)
The password input is replaced with `PinInput` — a compact dot-display field backed by a hidden `<input type="tel">` so the numeric keyboard opens automatically on mobile.

### Settings (`Settings.tsx`)
Each child row gains a **Change PIN** button that expands an inline panel with a `PinInput` and save/cancel. Uses the existing `PATCH /children/:id` endpoint with `{ password: pin }` — no backend changes required.

## New components

| Component | Used in | Purpose |
|---|---|---|
| `NumericKeypad` | Child login modal | Large-button keypad for children |
| `PinInput` | Parent forms | Compact inline PIN setter |

## Notes
- PIN length is capped at 6 digits with no enforced minimum beyond 1. Consider enforcing a minimum of 4 once existing children have their passwords migrated to numeric PINs.
- No API changes — the backend already accepts any string as `password`.