### PR TITLE
fix: improve mobile layout for iPhone

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,15 @@
 FROM mcr.microsoft.com/devcontainers/base:ubuntu-24.04
 
-# use this Dockerfile to install additional tools you might need, e.g.
-# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-#     && apt-get -y install --no-install-recommends <your-package-list-here>
+# Node.js 20 (LTS)
+RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
+    && apt-get install -y nodejs \
+    && npm install -g npm@latest
+
+# Playwright system-level browser dependencies (no browsers downloaded here —
+# browsers are fetched per-user at postCreate via `playwright install chromium`)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        libnss3 libatk1.0-0 libatk-bridge2.0-0 libcups2 libdrm2 \
+        libxkbcommon0 libxcomposite1 libxdamage1 libxfixes3 libxrandr2 \
+        libgbm1 libasound2t64 libpango-1.0-0 libpangocairo-1.0-0 \
+        libx11-xcb1 libxcb-dri3-0 libxshmfence1 \
+    && rm -rf /var/lib/apt/lists/*

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,23 +1,13 @@
-// The Dev Container format allows you to configure your environment. At the heart of it
-// is a Docker image or Dockerfile which controls the tools available in your environment.
-//
-// See https://aka.ms/devcontainer.json for more information.
 {
 	"name": "Ona",
-	// Use "image": "mcr.microsoft.com/devcontainers/base:ubuntu-24.04",
-	// instead of the build to use a pre-built image.
 	"build": {
-        "context": ".",
-        "dockerfile": "Dockerfile"
-    }
+		"context": ".",
+		"dockerfile": "Dockerfile"
+	},
+
+	// Install npm deps and download the Playwright Chromium browser after the container is created.
+	"postCreateCommand": "npm install && npx playwright install chromium",
+
 	// Copy SSH keys from secrets mount into ~/.ssh on every container start.
 	"postStartCommand": "mkdir -p ~/.ssh && chmod 700 ~/.ssh && cp /usr/local/secrets/id_ed25519 ~/.ssh/id_ed25519 && cp /usr/local/secrets/id_ed25519_pub ~/.ssh/id_ed25519.pub && chmod 600 ~/.ssh/id_ed25519 && chmod 644 ~/.ssh/id_ed25519.pub && printf 'Host exe.dev *.exe.xyz\\n  IdentitiesOnly yes\\n  IdentityFile ~/.ssh/id_ed25519\\n  StrictHostKeyChecking accept-new\\n' > ~/.ssh/config && chmod 600 ~/.ssh/config"
-
-	// Features add additional features to your environment. See https://containers.dev/features
-	// Beware: features are not supported on all platforms and may have unintended side-effects.
-	// "features": {
-    //   "ghcr.io/devcontainers/features/docker-in-docker": {
-    //     "moby": false
-    //   }
-    // }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
         "web"
       ],
       "devDependencies": {
+        "@playwright/test": "^1.59.1",
         "concurrently": "^8.2.2"
       }
     },
@@ -2645,6 +2646,21 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@popperjs/core": {
@@ -8605,6 +8621,50 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "ci": "npm run test"
   },
   "devDependencies": {
+    "@playwright/test": "^1.59.1",
     "concurrently": "^8.2.2"
   }
 }

--- a/web/src/styles/landing.css
+++ b/web/src/styles/landing.css
@@ -120,6 +120,8 @@
 
 @media (max-width: 768px) {
   .lp-nav-links { display: none; }
+  /* Hide the ghost "I'm a Kid" button in the nav on mobile — it's in the hamburger menu */
+  .lp-nav-actions .lp-btn-ghost { display: none; }
 }
 
 /* ── BUTTONS ── */
@@ -777,9 +779,22 @@
 }
 .lp-modal {
   position: fixed; inset: 0;
-  display: grid; place-items: center;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
   z-index: 201;
   padding: 16px;
+  overflow-y: auto;
+  /* Center vertically when content fits, scroll when it doesn't */
+  padding-top: max(16px, env(safe-area-inset-top));
+  padding-bottom: max(16px, env(safe-area-inset-bottom));
+}
+/* Vertical centering trick: flex column with auto margins */
+.lp-modal::before,
+.lp-modal::after {
+  content: '';
+  flex: 1;
+  min-height: 16px;
 }
 .lp-modal-card {
   background: #1A1040;
@@ -790,7 +805,8 @@
   box-shadow: 0 40px 80px rgba(0,0,0,0.6), inset 0 1px 0 rgba(255,255,255,0.1);
   animation: scaleIn 200ms ease;
   position: relative;
-  overflow: hidden;
+  overflow: visible;
+  flex-shrink: 0;
 }
 .lp-modal-card::before {
   content: '';
@@ -1010,4 +1026,47 @@
 @media (min-width: 400px) {
   .kp-grid { max-width: 300px; }
   .kp-key { min-height: 72px; font-size: 28px; }
+}
+
+/* ── iPhone / small-screen overrides ── */
+@media (max-width: 480px) {
+  /* Tighter modal padding so content fits without scrolling as much */
+  .lp-modal-card {
+    padding: 24px 20px;
+    border-radius: 20px;
+  }
+  .lp-modal-icon { font-size: 36px; margin-bottom: 8px; }
+  .lp-modal h2 { font-size: 22px; }
+  .lp-modal-sub { font-size: 13px; margin-bottom: 18px; }
+  .lp-form-group { margin-bottom: 12px; }
+
+  /* Compact keypad on small screens */
+  .kp-root { gap: 12px; }
+  .kp-grid { gap: 8px; }
+  .kp-key { min-height: 52px; font-size: 22px; border-radius: 12px; }
+  .kp-dot { width: 12px; height: 12px; }
+
+  /* Hero: reduce vertical padding and hide the game card mockup to save space */
+  .lp-hero {
+    padding-top: clamp(32px, 8vw, 60px);
+    padding-bottom: clamp(32px, 8vw, 60px);
+    gap: 32px;
+  }
+  .lp-hero-visual { display: none; }
+
+  /* Tighter hero text */
+  .lp-hero h1 { font-size: clamp(32px, 9vw, 48px); margin-bottom: 14px; }
+  .lp-hero-sub { font-size: 15px; margin-bottom: 24px; }
+  .lp-hero-cta { gap: 10px; }
+  .lp-hero-cta .lp-btn-lg { font-size: 15px; padding: 13px 22px; }
+
+  /* Social proof: smaller */
+  .lp-hero-social-proof { margin-top: 20px; }
+
+  /* Stats ribbon: 2-column grid */
+  .lp-stats-inner { flex-wrap: wrap; }
+  .lp-stat-item { min-width: 50%; }
+
+  /* Section headings */
+  .lp-section-h2 { font-size: clamp(26px, 7vw, 36px); }
 }

--- a/web/src/styles/landing.css
+++ b/web/src/styles/landing.css
@@ -780,21 +780,11 @@
 .lp-modal {
   position: fixed; inset: 0;
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   justify-content: center;
   z-index: 201;
-  padding: 16px;
-  overflow-y: auto;
-  /* Center vertically when content fits, scroll when it doesn't */
-  padding-top: max(16px, env(safe-area-inset-top));
-  padding-bottom: max(16px, env(safe-area-inset-bottom));
-}
-/* Vertical centering trick: flex column with auto margins */
-.lp-modal::before,
-.lp-modal::after {
-  content: '';
-  flex: 1;
-  min-height: 16px;
+  padding: max(12px, env(safe-area-inset-top)) 16px max(12px, env(safe-area-inset-bottom));
+  box-sizing: border-box;
 }
 .lp-modal-card {
   background: #1A1040;
@@ -802,12 +792,16 @@
   border-radius: 24px;
   padding: 36px;
   width: min(480px, 100%);
+  /* Card scrolls internally when taller than the available space */
+  max-height: calc(100dvh - max(24px, env(safe-area-inset-top)) - max(24px, env(safe-area-inset-bottom)));
+  overflow-y: auto;
   box-shadow: 0 40px 80px rgba(0,0,0,0.6), inset 0 1px 0 rgba(255,255,255,0.1);
   animation: scaleIn 200ms ease;
   position: relative;
-  overflow: visible;
-  flex-shrink: 0;
 }
+/* Remove the centering spacers — no longer needed */
+.lp-modal::before,
+.lp-modal::after { display: none; }
 .lp-modal-card::before {
   content: '';
   position: absolute; top: 0; left: 0; right: 0;
@@ -983,8 +977,7 @@
 }
 
 .kp-key {
-  aspect-ratio: 1;
-  min-height: 64px;
+  height: 60px;
   border-radius: 16px;
   border: 1px solid rgba(255, 255, 255, 0.15);
   background: rgba(255, 255, 255, 0.07);
@@ -1025,7 +1018,7 @@
 
 @media (min-width: 400px) {
   .kp-grid { max-width: 300px; }
-  .kp-key { min-height: 72px; font-size: 28px; }
+  .kp-key { height: 68px; font-size: 28px; }
 }
 
 /* ── iPhone / small-screen overrides ── */
@@ -1041,9 +1034,9 @@
   .lp-form-group { margin-bottom: 12px; }
 
   /* Compact keypad on small screens */
-  .kp-root { gap: 12px; }
+  .kp-root { gap: 10px; }
   .kp-grid { gap: 8px; }
-  .kp-key { min-height: 52px; font-size: 22px; border-radius: 12px; }
+  .kp-key { height: 52px; font-size: 20px; border-radius: 12px; }
   .kp-dot { width: 12px; height: 12px; }
 
   /* Hero: reduce vertical padding and hide the game card mockup to save space */


### PR DESCRIPTION
Closes #50

## What changed

### Kid login dialog — button below the fold
The numeric keypad was using `aspect-ratio: 1` with no height cap, so keys grew proportionally with the card width (~128px each on desktop, ~89px on mobile). Four rows of keys alone consumed 500px+, pushing the submit button off screen.

**Fix:** Replace `aspect-ratio: 1` with fixed `height` values per breakpoint (60px default, 68px at ≥400px, 52px at ≤480px). The modal container also now uses `max-height: 100dvh` with internal scroll as a safety net for very short viewports.

### Homepage on iPhone
- Game card mockup hidden at ≤480px — it was consuming half the viewport before the hero text
- Hero padding and font sizes tightened for narrow viewports
- Redundant "I'm a Kid" ghost button hidden from the nav bar on mobile (already present in the hamburger menu)

### Devcontainer
- **Dockerfile:** installs Node.js 20 LTS and Playwright's Chromium OS-level dependencies
- **devcontainer.json:** adds `postCreateCommand` to run `npm install && npx playwright install chromium`; fixes a pre-existing syntax error (missing comma after `build` block)
- **package.json:** adds `@playwright/test` as a root devDependency

## Verified with Playwright

Automated checks across 4 viewports (iPhone SE 375×667, iPhone 14 390×844, iPhone 14 Pro Max 430×932, desktop 1280×800):

| Check | iPhone SE | iPhone 14 | iPhone 14 Pro Max | Desktop |
|---|---|---|---|---|
| Hero h1 visible | ✅ | ✅ | ✅ | ✅ |
| Game card hidden ≤480px | ✅ | ✅ | ✅ | — |
| Nav ghost btn hidden on mobile | ✅ | ✅ | ✅ | — |
| Submit button in viewport | ✅ | ✅ | ✅ | ✅ |